### PR TITLE
fix(docs): correct Go module path to github.com/johnmartinez/cgm-get-agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Canonical spec: `SPEC.md`. This file is the source of truth. Never deviate from 
 
 ### Phase 1 — Scaffolding (branch: `feat/scaffolding`)
 Files to create:
-- `go.mod` — module `github.com/yourusername/cgm-get-agent`, Go 1.22
+- `go.mod` — module `github.com/johnmartinez/cgm-get-agent`, Go 1.22
 - `.gitignore` — see Security Gitignore section below
 - `.env.example` — placeholder values only
 - `Dockerfile` — multi-stage, CGO enabled, arm64-native
@@ -208,7 +208,7 @@ Data endpoints:
 
 ## Go Module Name
 
-`github.com/jmverleger/cgm-get-agent` (or match the actual GitHub repo URL — update if different)
+`github.com/johnmartinez/cgm-get-agent`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ An MCP (Model Context Protocol) server that connects LLMs (Claude, ChatGPT) to a
 ### 1. Clone and configure
 
 ```bash
-git clone https://github.com/yourusername/cgm-get-agent
+git clone https://github.com/johnmartinez/cgm-get-agent
 cd cgm-get-agent
 
 cp .env.example .env


### PR DESCRIPTION
## Summary
- Replace `github.com/jmverleger/cgm-get-agent` with correct path in `CLAUDE.md`
- Replace `github.com/yourusername/cgm-get-agent` placeholder in `CLAUDE.md` and `README.md`

## Test plan
- [x] Verified no `jmverleger` or `yourusername` references remain in any tracked file

🤖 Generated with [Claude Code](https://claude.com/claude-code)