### PR TITLE
feat(scaffolding): add project skeleton, Dockerfile, and docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# CGM Get Agent — Environment Configuration
+# Copy this file to .env and fill in your values.
+# .env is gitignored and must never be committed.
+
+# -------------------------------------------------------------------
+# Dexcom Developer App Credentials
+# Register at https://developer.dexcom.com to obtain these values.
+# -------------------------------------------------------------------
+GA_DEXCOM_CLIENT_ID=your-dexcom-client-id
+GA_DEXCOM_CLIENT_SECRET=your-dexcom-client-secret
+
+# Dexcom environment: "sandbox" for development, "production" for live CGM data.
+# Sandbox provides simulated G7 data — no real CGM required for development.
+GA_DEXCOM_ENV=sandbox
+
+# -------------------------------------------------------------------
+# Encryption
+# AES-256-GCM key for OAuth token storage (32 bytes, hex-encoded).
+# Generate with: openssl rand -hex 32
+# -------------------------------------------------------------------
+GA_ENCRYPTION_KEY=replace-with-output-of-openssl-rand-hex-32
+
+# -------------------------------------------------------------------
+# Storage paths (defaults shown — only set to override)
+# -------------------------------------------------------------------
+# GA_DB_PATH=/data/data.db
+# GA_TOKEN_PATH=/data/tokens.enc
+# GA_CONFIG_PATH=/data/config.yaml
+
+# -------------------------------------------------------------------
+# Server configuration (defaults shown — only set to override)
+# -------------------------------------------------------------------
+# GA_SERVER_PORT=8080
+# GA_MCP_TRANSPORT=sse

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Credentials and secrets — never commit these
+.env
+*.enc
+*.key
+*.pem
+
+# SQLite database files
+data.db
+data.db-shm
+data.db-wal
+
+# Config override (runtime config, not example)
+config.yaml
+
+# Local data directory
+.cgm-get-agent/
+
+# Go build artifacts
+*.exe
+*.test
+*.out
+/cgm-get-agent
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# macOS
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Stage 1: Build
+# CGO is required for mattn/go-sqlite3.
+FROM --platform=linux/arm64 golang:1.22-alpine AS builder
+
+RUN apk add --no-cache gcc musl-dev sqlite-dev
+
+WORKDIR /src
+
+# Download dependencies first (cached layer unless go.mod/go.sum change)
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=arm64 \
+    go build -ldflags="-s -w" -o /cgm-get-agent ./cmd/server
+
+# Stage 2: Runtime
+FROM --platform=linux/arm64 alpine:3.19
+
+# ca-certificates: HTTPS to Dexcom API
+# sqlite-libs:     runtime SQLite shared library for CGO binary
+# wget:            Docker healthcheck (GET /health)
+RUN apk add --no-cache ca-certificates sqlite-libs wget
+
+COPY --from=builder /cgm-get-agent /usr/local/bin/cgm-get-agent
+
+EXPOSE 8080
+
+ENTRYPOINT ["cgm-get-agent", "serve"]

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 || os.Args[1] != "serve" {
+		fmt.Fprintln(os.Stderr, "usage: cgm-get-agent serve")
+		os.Exit(1)
+	}
+	// Full server implementation added in feat/mcp-server phase.
+	fmt.Fprintln(os.Stderr, "cgm-get-agent: server not yet implemented")
+	os.Exit(1)
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,22 @@
+services:
+  cgm-get-agent:
+    build: .
+    container_name: cgm-get-agent
+    ports:
+      - "8080:8080"
+    volumes:
+      - ~/.cgm-get-agent:/data
+    env_file:
+      - .env
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - cgm-get-agent-net
+
+networks:
+  cgm-get-agent-net:
+    driver: bridge

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/johnmartinez/cgm-get-agent
+
+go 1.22


### PR DESCRIPTION
## Summary
- `go.mod` — module `github.com/johnmartinez/cgm-get-agent`, Go 1.22
- `.gitignore` — excludes `.env`, `*.enc`, `data.db`, `config.yaml`, `.cgm-get-agent/`
- `.env.example` — all `GA_*` variables with placeholder values and inline docs
- `Dockerfile` — multi-stage arm64 build; `CGO_ENABLED=1`; `alpine:3.19` runtime with `wget` for healthcheck
- `docker-compose.yaml` — `cgm-get-agent` service, `~/.cgm-get-agent:/data` volume, bridge network
- `cmd/server/main.go` — stub entrypoint (compiles clean, full server in Phase 5)

## Test plan
- [x] `go vet ./...` passes
- [x] `go mod tidy` produces no changes
- [ ] `docker compose build` succeeds on Apple Silicon

🤖 Generated with [Claude Code](https://claude.com/claude-code)