### PR TITLE
feat(core-packages): add types, config, crypto, and SQLite store packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/johnmartinez/cgm-get-agent
 
 go 1.22
+
+require (
+	github.com/mattn/go-sqlite3 v1.14.34
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/mattn/go-sqlite3 v1.14.34 h1:3NtcvcUnFBPsuRcno8pUtupspG/GM+9nZ88zgJcp6Zk=
+github.com/mattn/go-sqlite3 v1.14.34/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,150 @@
+// Package config loads and validates application configuration from an optional
+// YAML file and GA_* environment variable overrides.
+//
+// Loading order:
+//  1. Apply built-in defaults.
+//  2. Parse GA_CONFIG_PATH YAML (default: /data/config.yaml) if the file exists.
+//  3. Override any field set by a GA_* environment variable.
+//  4. Validate required fields; fail fast if any are missing or malformed.
+package config
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
+// GlucoseZones defines mg/dL thresholds for zone classification.
+// All values are inclusive lower bounds for that zone.
+type GlucoseZones struct {
+	Low        int `yaml:"low"`
+	TargetLow  int `yaml:"target_low"`
+	TargetHigh int `yaml:"target_high"`
+	Elevated   int `yaml:"elevated"`
+	High       int `yaml:"high"`
+}
+
+// Config is the fully resolved application configuration.
+// EncryptionKey is always sourced from GA_ENCRYPTION_KEY and never written to YAML.
+type Config struct {
+	Dexcom struct {
+		ClientID     string `yaml:"client_id"`
+		ClientSecret string `yaml:"client_secret"`
+		Environment  string `yaml:"environment"`
+		RedirectURI  string `yaml:"redirect_uri"`
+	} `yaml:"dexcom"`
+	Server struct {
+		Port int    `yaml:"port"`
+		Host string `yaml:"host"`
+	} `yaml:"server"`
+	Storage struct {
+		DBPath    string `yaml:"db_path"`
+		TokenPath string `yaml:"token_path"`
+	} `yaml:"storage"`
+	EncryptionKey []byte       // decoded from GA_ENCRYPTION_KEY; never in YAML
+	GlucoseZones  GlucoseZones `yaml:"glucose_zones"`
+}
+
+// Load builds a Config by applying defaults, YAML file (if present), env overrides,
+// and finally validating required fields. It returns an error on the first violation.
+func Load() (*Config, error) {
+	cfg := defaults()
+
+	if path := envOr("GA_CONFIG_PATH", "/data/config.yaml"); fileExists(path) {
+		if err := loadYAML(path, cfg); err != nil {
+			return nil, fmt.Errorf("config: loading yaml %q: %w", path, err)
+		}
+	}
+
+	applyEnv(cfg)
+
+	if err := validate(cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+func defaults() *Config {
+	cfg := &Config{}
+	cfg.Dexcom.Environment = "sandbox"
+	cfg.Dexcom.RedirectURI = "http://localhost:8080/callback"
+	cfg.Server.Port = 8080
+	cfg.Server.Host = "0.0.0.0"
+	cfg.Storage.DBPath = "/data/data.db"
+	cfg.Storage.TokenPath = "/data/tokens.enc"
+	cfg.GlucoseZones = GlucoseZones{
+		Low:        70,
+		TargetLow:  80,
+		TargetHigh: 120,
+		Elevated:   140,
+		High:       180,
+	}
+	return cfg
+}
+
+func loadYAML(path string, cfg *Config) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return yaml.NewDecoder(f).Decode(cfg)
+}
+
+func applyEnv(cfg *Config) {
+	if v := os.Getenv("GA_DEXCOM_CLIENT_ID"); v != "" {
+		cfg.Dexcom.ClientID = v
+	}
+	if v := os.Getenv("GA_DEXCOM_CLIENT_SECRET"); v != "" {
+		cfg.Dexcom.ClientSecret = v
+	}
+	if v := os.Getenv("GA_DEXCOM_ENV"); v != "" {
+		cfg.Dexcom.Environment = v
+	}
+	if v := os.Getenv("GA_SERVER_PORT"); v != "" {
+		if p, err := strconv.Atoi(v); err == nil {
+			cfg.Server.Port = p
+		}
+	}
+	if v := os.Getenv("GA_DB_PATH"); v != "" {
+		cfg.Storage.DBPath = v
+	}
+	if v := os.Getenv("GA_TOKEN_PATH"); v != "" {
+		cfg.Storage.TokenPath = v
+	}
+}
+
+func validate(cfg *Config) error {
+	if cfg.Dexcom.ClientID == "" {
+		return fmt.Errorf("config: GA_DEXCOM_CLIENT_ID is required")
+	}
+	if cfg.Dexcom.ClientSecret == "" {
+		return fmt.Errorf("config: GA_DEXCOM_CLIENT_SECRET is required")
+	}
+	keyHex := os.Getenv("GA_ENCRYPTION_KEY")
+	if keyHex == "" {
+		return fmt.Errorf("config: GA_ENCRYPTION_KEY is required")
+	}
+	key, err := hex.DecodeString(keyHex)
+	if err != nil || len(key) != 32 {
+		return fmt.Errorf("config: GA_ENCRYPTION_KEY must be 64 hex chars (32 bytes); got %d chars", len(keyHex))
+	}
+	cfg.EncryptionKey = key
+	return nil
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,209 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// validKey is a 64-char hex string representing a 32-byte AES key.
+const validKey = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+
+func setRequiredEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("GA_DEXCOM_CLIENT_ID", "test-client-id")
+	t.Setenv("GA_DEXCOM_CLIENT_SECRET", "test-secret")
+	t.Setenv("GA_ENCRYPTION_KEY", validKey)
+}
+
+func clearRequiredEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("GA_DEXCOM_CLIENT_ID", "")
+	t.Setenv("GA_DEXCOM_CLIENT_SECRET", "")
+	t.Setenv("GA_ENCRYPTION_KEY", "")
+}
+
+func TestLoad_MissingClientID(t *testing.T) {
+	clearRequiredEnv(t)
+	t.Setenv("GA_DEXCOM_CLIENT_SECRET", "some-secret")
+	t.Setenv("GA_ENCRYPTION_KEY", validKey)
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when GA_DEXCOM_CLIENT_ID is missing")
+	}
+}
+
+func TestLoad_MissingClientSecret(t *testing.T) {
+	clearRequiredEnv(t)
+	t.Setenv("GA_DEXCOM_CLIENT_ID", "some-id")
+	t.Setenv("GA_ENCRYPTION_KEY", validKey)
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when GA_DEXCOM_CLIENT_SECRET is missing")
+	}
+}
+
+func TestLoad_MissingEncryptionKey(t *testing.T) {
+	clearRequiredEnv(t)
+	t.Setenv("GA_DEXCOM_CLIENT_ID", "some-id")
+	t.Setenv("GA_DEXCOM_CLIENT_SECRET", "some-secret")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when GA_ENCRYPTION_KEY is missing")
+	}
+}
+
+func TestLoad_InvalidEncryptionKey_TooShort(t *testing.T) {
+	clearRequiredEnv(t)
+	t.Setenv("GA_DEXCOM_CLIENT_ID", "some-id")
+	t.Setenv("GA_DEXCOM_CLIENT_SECRET", "some-secret")
+	t.Setenv("GA_ENCRYPTION_KEY", "tooshort")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for too-short encryption key")
+	}
+}
+
+func TestLoad_InvalidEncryptionKey_NotHex(t *testing.T) {
+	clearRequiredEnv(t)
+	t.Setenv("GA_DEXCOM_CLIENT_ID", "some-id")
+	t.Setenv("GA_DEXCOM_CLIENT_SECRET", "some-secret")
+	// 64 chars but not valid hex
+	t.Setenv("GA_ENCRYPTION_KEY", "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for non-hex encryption key")
+	}
+}
+
+func TestLoad_EnvOverridesDefaults(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("GA_DEXCOM_ENV", "production")
+	t.Setenv("GA_SERVER_PORT", "9090")
+	t.Setenv("GA_DB_PATH", "/tmp/test.db")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Dexcom.Environment != "production" {
+		t.Errorf("expected environment=production, got %q", cfg.Dexcom.Environment)
+	}
+	if cfg.Server.Port != 9090 {
+		t.Errorf("expected port=9090, got %d", cfg.Server.Port)
+	}
+	if cfg.Storage.DBPath != "/tmp/test.db" {
+		t.Errorf("expected db_path=/tmp/test.db, got %q", cfg.Storage.DBPath)
+	}
+	if len(cfg.EncryptionKey) != 32 {
+		t.Errorf("expected 32-byte encryption key, got %d bytes", len(cfg.EncryptionKey))
+	}
+}
+
+func TestLoad_Defaults(t *testing.T) {
+	setRequiredEnv(t)
+	// Clear optional overrides
+	t.Setenv("GA_DEXCOM_ENV", "")
+	t.Setenv("GA_SERVER_PORT", "")
+	t.Setenv("GA_DB_PATH", "")
+	t.Setenv("GA_TOKEN_PATH", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Dexcom.Environment != "sandbox" {
+		t.Errorf("expected default environment=sandbox, got %q", cfg.Dexcom.Environment)
+	}
+	if cfg.Server.Port != 8080 {
+		t.Errorf("expected default port=8080, got %d", cfg.Server.Port)
+	}
+	if cfg.Storage.DBPath != "/data/data.db" {
+		t.Errorf("expected default db_path, got %q", cfg.Storage.DBPath)
+	}
+	if cfg.Storage.TokenPath != "/data/tokens.enc" {
+		t.Errorf("expected default token_path, got %q", cfg.Storage.TokenPath)
+	}
+}
+
+func TestLoad_GlucoseZoneDefaults(t *testing.T) {
+	setRequiredEnv(t)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	z := cfg.GlucoseZones
+	if z.Low != 70 {
+		t.Errorf("expected low=70, got %d", z.Low)
+	}
+	if z.TargetLow != 80 {
+		t.Errorf("expected target_low=80, got %d", z.TargetLow)
+	}
+	if z.TargetHigh != 120 {
+		t.Errorf("expected target_high=120, got %d", z.TargetHigh)
+	}
+	if z.Elevated != 140 {
+		t.Errorf("expected elevated=140, got %d", z.Elevated)
+	}
+	if z.High != 180 {
+		t.Errorf("expected high=180, got %d", z.High)
+	}
+}
+
+func TestLoad_YAMLOverridesDefaults(t *testing.T) {
+	setRequiredEnv(t)
+
+	yaml := `
+dexcom:
+  environment: production
+server:
+  port: 7777
+glucose_zones:
+  target_high: 130
+`
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(yamlPath, []byte(yaml), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GA_CONFIG_PATH", yamlPath)
+	t.Setenv("GA_DEXCOM_ENV", "") // env does not override; YAML should win for env field
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Dexcom.Environment != "production" {
+		t.Errorf("expected YAML environment=production, got %q", cfg.Dexcom.Environment)
+	}
+	if cfg.Server.Port != 7777 {
+		t.Errorf("expected YAML port=7777, got %d", cfg.Server.Port)
+	}
+	if cfg.GlucoseZones.TargetHigh != 130 {
+		t.Errorf("expected YAML target_high=130, got %d", cfg.GlucoseZones.TargetHigh)
+	}
+}
+
+func TestLoad_EnvWinsOverYAML(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("GA_DEXCOM_ENV", "sandbox") // env should win over YAML
+
+	yaml := `
+dexcom:
+  environment: production
+`
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(yamlPath, []byte(yaml), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GA_CONFIG_PATH", yamlPath)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Dexcom.Environment != "sandbox" {
+		t.Errorf("env var should win over YAML: expected sandbox, got %q", cfg.Dexcom.Environment)
+	}
+}

--- a/internal/crypto/tokens.go
+++ b/internal/crypto/tokens.go
@@ -1,0 +1,117 @@
+// Package crypto provides AES-256-GCM encryption for OAuth token storage.
+//
+// Token file format: base64(12-byte-nonce || AES-256-GCM-ciphertext)
+// Key source: GA_ENCRYPTION_KEY env var (32 bytes, hex-encoded) — never hardcoded.
+//
+// Atomic write guarantee: SaveTokens writes to a .tmp file then renames, ensuring
+// the token file is never partially written even on crash or power loss.
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/johnmartinez/cgm-get-agent/internal/types"
+)
+
+// Encrypt encrypts plaintext using AES-256-GCM with a random nonce.
+// key must be exactly 32 bytes.
+// Output: base64(12-byte-nonce || ciphertext || 16-byte-GCM-tag).
+func Encrypt(plaintext, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: creating cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: creating GCM: %w", err)
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("crypto: generating nonce: %w", err)
+	}
+	// Seal appends ciphertext+tag to nonce, giving us nonce||ciphertext||tag.
+	sealed := gcm.Seal(nonce, nonce, plaintext, nil)
+	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(sealed)))
+	base64.StdEncoding.Encode(encoded, sealed)
+	return encoded, nil
+}
+
+// Decrypt decrypts a value produced by Encrypt.
+// Returns an error if the key is wrong or the ciphertext has been tampered with.
+func Decrypt(ciphertext, key []byte) ([]byte, error) {
+	raw := make([]byte, base64.StdEncoding.DecodedLen(len(ciphertext)))
+	n, err := base64.StdEncoding.Decode(raw, ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: base64 decode: %w", err)
+	}
+	raw = raw[:n]
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: creating cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: creating GCM: %w", err)
+	}
+	if len(raw) < gcm.NonceSize() {
+		return nil, fmt.Errorf("crypto: ciphertext too short")
+	}
+	nonce, data := raw[:gcm.NonceSize()], raw[gcm.NonceSize():]
+	plaintext, err := gcm.Open(nil, nonce, data, nil)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: decryption failed (wrong key or tampered data): %w", err)
+	}
+	return plaintext, nil
+}
+
+// SaveTokens marshals tokens to JSON, encrypts with key, and atomically writes to path.
+// Atomic write: write to path+".tmp" then os.Rename to path (POSIX atomic on same filesystem).
+// Directory is created with mode 0700 if it does not exist.
+func SaveTokens(path string, tokens types.OAuthTokens, key []byte) error {
+	data, err := json.Marshal(tokens)
+	if err != nil {
+		return fmt.Errorf("crypto: marshaling tokens: %w", err)
+	}
+	encrypted, err := Encrypt(data, key)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("crypto: creating token directory: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, encrypted, 0600); err != nil {
+		return fmt.Errorf("crypto: writing temp token file: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("crypto: renaming token file: %w", err)
+	}
+	return nil
+}
+
+// LoadTokens reads, decrypts, and unmarshals OAuthTokens from path.
+// Returns an error if the file does not exist, the key is wrong, or the data is corrupt.
+func LoadTokens(path string, key []byte) (types.OAuthTokens, error) {
+	var tokens types.OAuthTokens
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return tokens, fmt.Errorf("crypto: reading token file: %w", err)
+	}
+	plaintext, err := Decrypt(data, key)
+	if err != nil {
+		return tokens, err
+	}
+	if err := json.Unmarshal(plaintext, &tokens); err != nil {
+		return tokens, fmt.Errorf("crypto: unmarshaling tokens: %w", err)
+	}
+	return tokens, nil
+}

--- a/internal/crypto/tokens_test.go
+++ b/internal/crypto/tokens_test.go
@@ -1,0 +1,159 @@
+package crypto_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/johnmartinez/cgm-get-agent/internal/crypto"
+	"github.com/johnmartinez/cgm-get-agent/internal/types"
+)
+
+var testKey = bytes.Repeat([]byte{0x01}, 32)
+var wrongKey = bytes.Repeat([]byte{0x02}, 32)
+
+func TestEncryptDecrypt_RoundTrip(t *testing.T) {
+	plaintext := []byte("test glucose token data")
+	ciphertext, err := crypto.Encrypt(plaintext, testKey)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if bytes.Equal(ciphertext, plaintext) {
+		t.Fatal("ciphertext must not equal plaintext")
+	}
+	got, err := crypto.Decrypt(ciphertext, testKey)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Errorf("round-trip failed: got %q, want %q", got, plaintext)
+	}
+}
+
+func TestEncrypt_ProducesUniqueCiphertexts(t *testing.T) {
+	// Two encryptions of the same plaintext must differ (random nonce).
+	plaintext := []byte("same plaintext")
+	c1, _ := crypto.Encrypt(plaintext, testKey)
+	c2, _ := crypto.Encrypt(plaintext, testKey)
+	if bytes.Equal(c1, c2) {
+		t.Error("two encryptions of same plaintext must differ (nonce reuse)")
+	}
+}
+
+func TestDecrypt_WrongKey(t *testing.T) {
+	ciphertext, _ := crypto.Encrypt([]byte("secret"), testKey)
+	_, err := crypto.Decrypt(ciphertext, wrongKey)
+	if err == nil {
+		t.Fatal("Decrypt with wrong key must return an error")
+	}
+}
+
+func TestDecrypt_TamperedCiphertext(t *testing.T) {
+	ciphertext, _ := crypto.Encrypt([]byte("secret"), testKey)
+	// Flip a byte in the middle of the ciphertext.
+	ciphertext[len(ciphertext)/2] ^= 0xFF
+	_, err := crypto.Decrypt(ciphertext, testKey)
+	if err == nil {
+		t.Fatal("Decrypt of tampered ciphertext must return an error")
+	}
+}
+
+func TestDecrypt_TooShort(t *testing.T) {
+	_, err := crypto.Decrypt([]byte("dG9vc2hvcnQ="), testKey) // base64("tooshort")
+	if err == nil {
+		t.Fatal("Decrypt of too-short ciphertext must return an error")
+	}
+}
+
+func TestSaveTokens_LoadTokens_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tokens.enc")
+
+	now := time.Now().UTC().Truncate(time.Second)
+	tokens := types.OAuthTokens{
+		AccessToken:   "access-abc",
+		RefreshToken:  "refresh-xyz",
+		ExpiresAt:     now.Add(30 * time.Minute),
+		LastRefreshed: now,
+	}
+
+	if err := crypto.SaveTokens(path, tokens, testKey); err != nil {
+		t.Fatalf("SaveTokens: %v", err)
+	}
+
+	// File must exist and be non-empty.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("token file not created: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("token file must not be empty")
+	}
+
+	got, err := crypto.LoadTokens(path, testKey)
+	if err != nil {
+		t.Fatalf("LoadTokens: %v", err)
+	}
+	if got.AccessToken != tokens.AccessToken {
+		t.Errorf("AccessToken mismatch: got %q, want %q", got.AccessToken, tokens.AccessToken)
+	}
+	if got.RefreshToken != tokens.RefreshToken {
+		t.Errorf("RefreshToken mismatch: got %q, want %q", got.RefreshToken, tokens.RefreshToken)
+	}
+	if !got.ExpiresAt.Equal(tokens.ExpiresAt) {
+		t.Errorf("ExpiresAt mismatch: got %v, want %v", got.ExpiresAt, tokens.ExpiresAt)
+	}
+}
+
+func TestSaveTokens_AtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tokens.enc")
+
+	tokens := types.OAuthTokens{AccessToken: "test"}
+	if err := crypto.SaveTokens(path, tokens, testKey); err != nil {
+		t.Fatalf("SaveTokens: %v", err)
+	}
+
+	// The .tmp file must have been cleaned up by the rename.
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Error("temp file must not exist after successful SaveTokens")
+	}
+}
+
+func TestSaveTokens_CreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	// Use a nested path that doesn't exist yet.
+	path := filepath.Join(dir, "nested", "dir", "tokens.enc")
+
+	tokens := types.OAuthTokens{AccessToken: "test"}
+	if err := crypto.SaveTokens(path, tokens, testKey); err != nil {
+		t.Fatalf("SaveTokens should create parent dirs: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("token file not found after save: %v", err)
+	}
+}
+
+func TestLoadTokens_FileNotFound(t *testing.T) {
+	_, err := crypto.LoadTokens("/nonexistent/tokens.enc", testKey)
+	if err == nil {
+		t.Fatal("LoadTokens on missing file must return an error")
+	}
+}
+
+func TestLoadTokens_WrongKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tokens.enc")
+
+	tokens := types.OAuthTokens{AccessToken: "test"}
+	if err := crypto.SaveTokens(path, tokens, testKey); err != nil {
+		t.Fatalf("SaveTokens: %v", err)
+	}
+
+	_, err := crypto.LoadTokens(path, wrongKey)
+	if err == nil {
+		t.Fatal("LoadTokens with wrong key must return an error")
+	}
+}

--- a/internal/store/cache.go
+++ b/internal/store/cache.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/johnmartinez/cgm-get-agent/internal/types"
+)
+
+// CacheEGVs upserts EGV records into glucose_cache using record_id as the dedup key.
+// Returns the number of records successfully written.
+func (s *Store) CacheEGVs(records []types.EGVRecord) (int, error) {
+	count := 0
+	for _, r := range records {
+		raw, err := json.Marshal(r)
+		if err != nil {
+			return count, fmt.Errorf("store: marshaling egv %s: %w", r.RecordID, err)
+		}
+		_, err = s.db.Exec(
+			`INSERT OR REPLACE INTO glucose_cache
+			 (record_id, system_time, display_time, value, trend, trend_rate, raw_json)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			r.RecordID,
+			r.SystemTime.UTC().Format(time.RFC3339),
+			r.DisplayTime.UTC().Format(time.RFC3339),
+			r.Value,
+			string(r.Trend),
+			r.TrendRate,
+			string(raw),
+		)
+		if err != nil {
+			return count, fmt.Errorf("store: caching egv %s: %w", r.RecordID, err)
+		}
+		count++
+	}
+	return count, nil
+}
+
+// GetCachedEGVs retrieves EGV records from the cache with system_time in [start, end],
+// ordered ascending by system_time.
+func (s *Store) GetCachedEGVs(start, end time.Time) ([]types.EGVRecord, error) {
+	rows, err := s.db.Query(
+		`SELECT raw_json FROM glucose_cache
+		 WHERE system_time >= ? AND system_time <= ?
+		 ORDER BY system_time ASC`,
+		start.UTC().Format(time.RFC3339),
+		end.UTC().Format(time.RFC3339),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: querying cached egvs: %w", err)
+	}
+	defer rows.Close()
+
+	var egvs []types.EGVRecord
+	for rows.Next() {
+		var raw string
+		if err := rows.Scan(&raw); err != nil {
+			return nil, fmt.Errorf("store: scanning cached egv: %w", err)
+		}
+		var r types.EGVRecord
+		if err := json.Unmarshal([]byte(raw), &r); err != nil {
+			return nil, fmt.Errorf("store: unmarshaling cached egv: %w", err)
+		}
+		egvs = append(egvs, r)
+	}
+	return egvs, rows.Err()
+}

--- a/internal/store/exercise.go
+++ b/internal/store/exercise.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/johnmartinez/cgm-get-agent/internal/types"
+)
+
+// SaveExercise persists an exercise session. ID and LoggedAt are auto-populated if zero.
+func (s *Store) SaveExercise(e types.Exercise) (types.Exercise, error) {
+	if e.ID == "" {
+		e.ID = types.ExerciseID(e.Timestamp)
+	}
+	if e.LoggedAt.IsZero() {
+		e.LoggedAt = time.Now().UTC()
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO exercise (id, type, duration_min, intensity, timestamp, logged_at, notes)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		e.ID, e.Type, e.DurationMin, string(e.Intensity),
+		e.Timestamp.UTC().Format(time.RFC3339),
+		e.LoggedAt.UTC().Format(time.RFC3339),
+		e.Notes,
+	)
+	if err != nil {
+		return e, fmt.Errorf("store: saving exercise: %w", err)
+	}
+	return e, nil
+}
+
+// ListExercise returns all exercise sessions whose timestamp falls within [start, end], ascending.
+func (s *Store) ListExercise(start, end time.Time) ([]types.Exercise, error) {
+	rows, err := s.db.Query(
+		`SELECT id, type, duration_min, intensity, timestamp, logged_at, notes
+		 FROM exercise WHERE timestamp >= ? AND timestamp <= ? ORDER BY timestamp ASC`,
+		start.UTC().Format(time.RFC3339),
+		end.UTC().Format(time.RFC3339),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: listing exercise: %w", err)
+	}
+	defer rows.Close()
+
+	var exercises []types.Exercise
+	for rows.Next() {
+		e, err := scanExercise(rows)
+		if err != nil {
+			return nil, err
+		}
+		exercises = append(exercises, e)
+	}
+	return exercises, rows.Err()
+}
+
+func scanExercise(s scanner) (types.Exercise, error) {
+	var e types.Exercise
+	var intensity, ts, loggedAt string
+	err := s.Scan(&e.ID, &e.Type, &e.DurationMin, &intensity, &ts, &loggedAt, &e.Notes)
+	if err != nil {
+		return e, fmt.Errorf("store: scanning exercise: %w", err)
+	}
+	e.Intensity = types.ExerciseIntensity(intensity)
+	e.Timestamp, _ = time.Parse(time.RFC3339, ts)
+	e.LoggedAt, _ = time.Parse(time.RFC3339, loggedAt)
+	return e, nil
+}

--- a/internal/store/meals.go
+++ b/internal/store/meals.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/johnmartinez/cgm-get-agent/internal/types"
+)
+
+// SaveMeal persists a meal record. If m.ID is empty it is generated from m.Timestamp.
+// If m.LoggedAt is zero it is set to the current UTC time.
+// Returns the stored record (with ID and LoggedAt populated).
+func (s *Store) SaveMeal(m types.Meal) (types.Meal, error) {
+	if m.ID == "" {
+		m.ID = types.MealID(m.Timestamp)
+	}
+	if m.LoggedAt.IsZero() {
+		m.LoggedAt = time.Now().UTC()
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO meals (id, description, carbs_est, protein_est, fat_est, timestamp, logged_at, notes)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		m.ID, m.Description, m.CarbsEst, m.ProteinEst, m.FatEst,
+		m.Timestamp.UTC().Format(time.RFC3339),
+		m.LoggedAt.UTC().Format(time.RFC3339),
+		m.Notes,
+	)
+	if err != nil {
+		return m, fmt.Errorf("store: saving meal: %w", err)
+	}
+	return m, nil
+}
+
+// GetMeal retrieves a meal by its ID. Returns an error if not found.
+func (s *Store) GetMeal(id string) (types.Meal, error) {
+	row := s.db.QueryRow(
+		`SELECT id, description, carbs_est, protein_est, fat_est, timestamp, logged_at, notes
+		 FROM meals WHERE id = ?`, id,
+	)
+	m, err := scanMeal(row)
+	if err == sql.ErrNoRows {
+		return m, fmt.Errorf("store: meal %q not found", id)
+	}
+	return m, err
+}
+
+// ListMeals returns all meals whose timestamp falls within [start, end], ascending.
+func (s *Store) ListMeals(start, end time.Time) ([]types.Meal, error) {
+	rows, err := s.db.Query(
+		`SELECT id, description, carbs_est, protein_est, fat_est, timestamp, logged_at, notes
+		 FROM meals WHERE timestamp >= ? AND timestamp <= ? ORDER BY timestamp ASC`,
+		start.UTC().Format(time.RFC3339),
+		end.UTC().Format(time.RFC3339),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: listing meals: %w", err)
+	}
+	defer rows.Close()
+
+	var meals []types.Meal
+	for rows.Next() {
+		m, err := scanMeal(rows)
+		if err != nil {
+			return nil, err
+		}
+		meals = append(meals, m)
+	}
+	return meals, rows.Err()
+}
+
+func scanMeal(s scanner) (types.Meal, error) {
+	var m types.Meal
+	var ts, loggedAt string
+	err := s.Scan(
+		&m.ID, &m.Description, &m.CarbsEst, &m.ProteinEst, &m.FatEst,
+		&ts, &loggedAt, &m.Notes,
+	)
+	if err != nil {
+		return m, err
+	}
+	m.Timestamp, _ = time.Parse(time.RFC3339, ts)
+	m.LoggedAt, _ = time.Parse(time.RFC3339, loggedAt)
+	return m, nil
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1,0 +1,125 @@
+// Package store provides SQLite-backed persistence for meals, exercise sessions,
+// and a glucose EGV cache. It uses versioned migrations applied on startup.
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Store wraps a SQLite database and exposes all persistence operations.
+type Store struct {
+	db *sql.DB
+}
+
+// migrations is the ordered list of SQL migration scripts.
+// Append new entries to add schema versions; never edit existing ones.
+var migrations = []string{
+	// v1: initial schema
+	`
+	CREATE TABLE IF NOT EXISTS meals (
+		id          TEXT PRIMARY KEY,
+		description TEXT NOT NULL,
+		carbs_est   REAL,
+		protein_est REAL,
+		fat_est     REAL,
+		timestamp   TEXT NOT NULL,
+		logged_at   TEXT NOT NULL,
+		notes       TEXT
+	);
+
+	CREATE TABLE IF NOT EXISTS exercise (
+		id           TEXT PRIMARY KEY,
+		type         TEXT NOT NULL,
+		duration_min INTEGER NOT NULL,
+		intensity    TEXT NOT NULL,
+		timestamp    TEXT NOT NULL,
+		logged_at    TEXT NOT NULL,
+		notes        TEXT
+	);
+
+	CREATE TABLE IF NOT EXISTS glucose_cache (
+		record_id    TEXT PRIMARY KEY,
+		system_time  TEXT NOT NULL,
+		display_time TEXT NOT NULL,
+		value        INTEGER NOT NULL,
+		trend        TEXT NOT NULL,
+		trend_rate   REAL,
+		raw_json     TEXT NOT NULL
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_meals_timestamp        ON meals (timestamp);
+	CREATE INDEX IF NOT EXISTS idx_exercise_timestamp     ON exercise (timestamp);
+	CREATE INDEX IF NOT EXISTS idx_glucose_cache_systime  ON glucose_cache (system_time);
+	`,
+}
+
+// Open opens (or creates) the SQLite database at path, enables WAL mode and
+// foreign keys, and runs any pending migrations. Returns a ready-to-use Store.
+func Open(path string) (*Store, error) {
+	db, err := sql.Open("sqlite3", path+"?_journal_mode=WAL&_foreign_keys=on")
+	if err != nil {
+		return nil, fmt.Errorf("store: opening db: %w", err)
+	}
+	if err := db.Ping(); err != nil {
+		return nil, fmt.Errorf("store: pinging db: %w", err)
+	}
+	if err := runMigrations(db); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("store: running migrations: %w", err)
+	}
+	return &Store{db: db}, nil
+}
+
+// Close closes the underlying database connection.
+func (s *Store) Close() error {
+	return s.db.Close()
+}
+
+// Ping checks that the database is still reachable.
+func (s *Store) Ping() error {
+	return s.db.Ping()
+}
+
+func runMigrations(db *sql.DB) error {
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS migrations (
+			version    INTEGER PRIMARY KEY,
+			applied_at TEXT NOT NULL
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("creating migrations table: %w", err)
+	}
+
+	var current int
+	if err := db.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM migrations`).Scan(&current); err != nil {
+		return fmt.Errorf("reading migration version: %w", err)
+	}
+
+	for i, ddl := range migrations {
+		version := i + 1
+		if version <= current {
+			continue
+		}
+		if _, err := db.Exec(ddl); err != nil {
+			return fmt.Errorf("applying migration v%d: %w", version, err)
+		}
+		_, err := db.Exec(
+			`INSERT INTO migrations (version, applied_at) VALUES (?, ?)`,
+			version, time.Now().UTC().Format(time.RFC3339),
+		)
+		if err != nil {
+			return fmt.Errorf("recording migration v%d: %w", version, err)
+		}
+	}
+	return nil
+}
+
+// scanner is satisfied by both *sql.Row and *sql.Rows.
+type scanner interface {
+	Scan(dest ...any) error
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,303 @@
+package store_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/johnmartinez/cgm-get-agent/internal/store"
+	"github.com/johnmartinez/cgm-get-agent/internal/types"
+)
+
+func testStore(t *testing.T) *store.Store {
+	t.Helper()
+	s, err := store.Open(":memory:")
+	if err != nil {
+		t.Fatalf("opening test store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// --- Migrations ---
+
+func TestOpen_MigrationsIdempotent(t *testing.T) {
+	s := testStore(t)
+	// Ping confirms DB is still healthy after migrations.
+	if err := s.Ping(); err != nil {
+		t.Errorf("Ping after Open: %v", err)
+	}
+}
+
+// --- Meal CRUD ---
+
+func TestSaveMeal_GeneratesID(t *testing.T) {
+	s := testStore(t)
+	ts := time.Date(2026, 3, 3, 12, 15, 0, 0, time.UTC)
+	m := types.Meal{Description: "tacos", Timestamp: ts}
+
+	saved, err := s.SaveMeal(m)
+	if err != nil {
+		t.Fatalf("SaveMeal: %v", err)
+	}
+	if saved.ID != "m_20260303_1215" {
+		t.Errorf("expected ID m_20260303_1215, got %q", saved.ID)
+	}
+	if saved.LoggedAt.IsZero() {
+		t.Error("LoggedAt must be set on save")
+	}
+}
+
+func TestGetMeal_RoundTrip(t *testing.T) {
+	s := testStore(t)
+	ts := time.Date(2026, 3, 3, 12, 15, 0, 0, time.UTC)
+	m := types.Meal{
+		Description: "carne asada tacos x3 with horchata",
+		CarbsEst:    ptr(70.0),
+		ProteinEst:  ptr(35.0),
+		Notes:       ptr("street tacos from the truck"),
+		Timestamp:   ts,
+	}
+
+	saved, err := s.SaveMeal(m)
+	if err != nil {
+		t.Fatalf("SaveMeal: %v", err)
+	}
+
+	got, err := s.GetMeal(saved.ID)
+	if err != nil {
+		t.Fatalf("GetMeal: %v", err)
+	}
+
+	if got.Description != m.Description {
+		t.Errorf("Description: got %q, want %q", got.Description, m.Description)
+	}
+	if got.CarbsEst == nil || *got.CarbsEst != 70.0 {
+		t.Errorf("CarbsEst mismatch")
+	}
+	if got.ProteinEst == nil || *got.ProteinEst != 35.0 {
+		t.Errorf("ProteinEst mismatch")
+	}
+	if got.Notes == nil || *got.Notes != "street tacos from the truck" {
+		t.Errorf("Notes mismatch")
+	}
+	if !got.Timestamp.Equal(ts) {
+		t.Errorf("Timestamp: got %v, want %v", got.Timestamp, ts)
+	}
+}
+
+func TestGetMeal_NotFound(t *testing.T) {
+	s := testStore(t)
+	_, err := s.GetMeal("m_99991231_2359")
+	if err == nil {
+		t.Fatal("GetMeal on missing ID must return an error")
+	}
+}
+
+func TestListMeals_TimeRange(t *testing.T) {
+	s := testStore(t)
+	base := time.Date(2026, 3, 3, 8, 0, 0, 0, time.UTC)
+
+	meals := []types.Meal{
+		{Description: "breakfast", Timestamp: base},
+		{Description: "lunch", Timestamp: base.Add(4 * time.Hour)},
+		{Description: "dinner", Timestamp: base.Add(10 * time.Hour)},
+	}
+	for _, m := range meals {
+		if _, err := s.SaveMeal(m); err != nil {
+			t.Fatalf("SaveMeal: %v", err)
+		}
+	}
+
+	// Query only breakfast and lunch.
+	got, err := s.ListMeals(base, base.Add(5*time.Hour))
+	if err != nil {
+		t.Fatalf("ListMeals: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 meals, got %d", len(got))
+	}
+	if got[0].Description != "breakfast" || got[1].Description != "lunch" {
+		t.Errorf("unexpected order or content: %+v", got)
+	}
+}
+
+// --- Exercise CRUD ---
+
+func TestSaveExercise_GeneratesID(t *testing.T) {
+	s := testStore(t)
+	ts := time.Date(2026, 3, 3, 14, 30, 0, 0, time.UTC)
+	e := types.Exercise{
+		Type:        "run",
+		DurationMin: 30,
+		Intensity:   types.IntensityModerateHigh,
+		Timestamp:   ts,
+	}
+
+	saved, err := s.SaveExercise(e)
+	if err != nil {
+		t.Fatalf("SaveExercise: %v", err)
+	}
+	if saved.ID != "e_20260303_1430" {
+		t.Errorf("expected ID e_20260303_1430, got %q", saved.ID)
+	}
+}
+
+func TestListExercise_RoundTrip(t *testing.T) {
+	s := testStore(t)
+	base := time.Date(2026, 3, 3, 6, 0, 0, 0, time.UTC)
+
+	sessions := []types.Exercise{
+		{Type: "kettlebell", DurationMin: 20, Intensity: types.IntensityHigh, Timestamp: base},
+		{Type: "walk", DurationMin: 45, Intensity: types.IntensityLow, Timestamp: base.Add(8 * time.Hour)},
+	}
+	for _, e := range sessions {
+		if _, err := s.SaveExercise(e); err != nil {
+			t.Fatalf("SaveExercise: %v", err)
+		}
+	}
+
+	got, err := s.ListExercise(base.Add(-time.Minute), base.Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("ListExercise: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(got))
+	}
+	if got[0].Type != "kettlebell" {
+		t.Errorf("expected kettlebell first, got %q", got[0].Type)
+	}
+	if got[1].Intensity != types.IntensityLow {
+		t.Errorf("intensity mismatch: got %q", got[1].Intensity)
+	}
+}
+
+func TestListExercise_Empty(t *testing.T) {
+	s := testStore(t)
+	got, err := s.ListExercise(time.Now().Add(-time.Hour), time.Now())
+	if err != nil {
+		t.Fatalf("ListExercise on empty store: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty slice, got %d", len(got))
+	}
+}
+
+// --- Glucose Cache ---
+
+func TestCacheEGVs_Upsert(t *testing.T) {
+	s := testStore(t)
+	base := time.Date(2026, 3, 3, 10, 0, 0, 0, time.UTC)
+
+	records := []types.EGVRecord{
+		{RecordID: "rec-1", SystemTime: base, DisplayTime: base, Value: 105, Trend: types.TrendFlat, TrendRate: 0.1, Unit: "mg/dL"},
+		{RecordID: "rec-2", SystemTime: base.Add(5 * time.Minute), DisplayTime: base.Add(5 * time.Minute), Value: 110, Trend: types.TrendFortyFiveUp, TrendRate: 1.2, Unit: "mg/dL"},
+		{RecordID: "rec-3", SystemTime: base.Add(10 * time.Minute), DisplayTime: base.Add(10 * time.Minute), Value: 118, Trend: types.TrendSingleUp, TrendRate: 2.1, Unit: "mg/dL"},
+	}
+
+	n, err := s.CacheEGVs(records)
+	if err != nil {
+		t.Fatalf("CacheEGVs: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("expected 3 cached, got %d", n)
+	}
+
+	// Upsert the same records — should not error or duplicate.
+	n2, err := s.CacheEGVs(records)
+	if err != nil {
+		t.Fatalf("CacheEGVs upsert: %v", err)
+	}
+	if n2 != 3 {
+		t.Errorf("upsert should still report 3, got %d", n2)
+	}
+}
+
+func TestGetCachedEGVs_TimeRange(t *testing.T) {
+	s := testStore(t)
+	base := time.Date(2026, 3, 3, 10, 0, 0, 0, time.UTC)
+
+	records := []types.EGVRecord{
+		{RecordID: "r1", SystemTime: base, Value: 100, Trend: types.TrendFlat},
+		{RecordID: "r2", SystemTime: base.Add(5 * time.Minute), Value: 110, Trend: types.TrendFlat},
+		{RecordID: "r3", SystemTime: base.Add(10 * time.Minute), Value: 120, Trend: types.TrendFlat},
+		{RecordID: "r4", SystemTime: base.Add(15 * time.Minute), Value: 130, Trend: types.TrendFlat},
+	}
+	if _, err := s.CacheEGVs(records); err != nil {
+		t.Fatalf("CacheEGVs: %v", err)
+	}
+
+	// Request only r2 and r3.
+	got, err := s.GetCachedEGVs(base.Add(4*time.Minute), base.Add(11*time.Minute))
+	if err != nil {
+		t.Fatalf("GetCachedEGVs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2, got %d", len(got))
+	}
+	if got[0].RecordID != "r2" || got[1].RecordID != "r3" {
+		t.Errorf("unexpected records: %v", got)
+	}
+	// Verify ascending order.
+	if !got[0].SystemTime.Before(got[1].SystemTime) {
+		t.Error("GetCachedEGVs must return records in ascending SystemTime order")
+	}
+}
+
+func TestGetCachedEGVs_Empty(t *testing.T) {
+	s := testStore(t)
+	got, err := s.GetCachedEGVs(time.Now().Add(-time.Hour), time.Now())
+	if err != nil {
+		t.Fatalf("GetCachedEGVs on empty cache: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty slice, got %d", len(got))
+	}
+}
+
+func TestCacheEGVs_PreservesAllFields(t *testing.T) {
+	s := testStore(t)
+	base := time.Date(2026, 3, 3, 10, 0, 0, 0, time.UTC)
+
+	r := types.EGVRecord{
+		RecordID:              "full-record",
+		SystemTime:            base,
+		DisplayTime:           base.Add(time.Hour),
+		TransmitterID:         "tx-abc",
+		TransmitterTicks:      12345,
+		Value:                 142,
+		Trend:                 types.TrendFortyFiveDown,
+		TrendRate:             -1.5,
+		Unit:                  "mg/dL",
+		RateUnit:              "mg/dL/min",
+		DisplayDevice:         "iOS",
+		TransmitterGeneration: "g7",
+		DisplayApp:            "G7",
+	}
+
+	if _, err := s.CacheEGVs([]types.EGVRecord{r}); err != nil {
+		t.Fatalf("CacheEGVs: %v", err)
+	}
+
+	got, err := s.GetCachedEGVs(base.Add(-time.Minute), base.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("GetCachedEGVs: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1, got %d", len(got))
+	}
+	g := got[0]
+	if g.RecordID != r.RecordID {
+		t.Errorf("RecordID: got %q", g.RecordID)
+	}
+	if g.Value != r.Value {
+		t.Errorf("Value: got %d, want %d", g.Value, r.Value)
+	}
+	if g.Trend != r.Trend {
+		t.Errorf("Trend: got %q, want %q", g.Trend, r.Trend)
+	}
+	if g.TransmitterGeneration != "g7" {
+		t.Errorf("TransmitterGeneration: got %q", g.TransmitterGeneration)
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,0 +1,171 @@
+// Package types defines all shared data structures used across packages.
+// Both internal/dexcom and internal/store import from here to avoid circular dependencies.
+package types
+
+import "time"
+
+// --- Dexcom API Types ---
+
+// TrendArrow represents the direction of glucose change as reported by the G7.
+type TrendArrow string
+
+const (
+	TrendDoubleUp       TrendArrow = "doubleUp"
+	TrendSingleUp       TrendArrow = "singleUp"
+	TrendFortyFiveUp    TrendArrow = "fortyFiveUp"
+	TrendFlat           TrendArrow = "flat"
+	TrendFortyFiveDown  TrendArrow = "fortyFiveDown"
+	TrendSingleDown     TrendArrow = "singleDown"
+	TrendDoubleDown     TrendArrow = "doubleDown"
+	TrendNone           TrendArrow = "none"
+	TrendNotComputable  TrendArrow = "notComputable"
+	TrendRateOutOfRange TrendArrow = "rateOutOfRange"
+)
+
+// EGVRecord is a single estimated glucose value from the Dexcom API.
+// Always use the Value field; do not use smoothed or realtime variants.
+// SystemTime is device clock time and may drift from true UTC — use it for
+// sequencing only, not wall-clock calculations.
+type EGVRecord struct {
+	RecordID              string     `json:"recordId"`
+	SystemTime            time.Time  `json:"systemTime"`
+	DisplayTime           time.Time  `json:"displayTime"`
+	TransmitterID         string     `json:"transmitterId"`
+	TransmitterTicks      int        `json:"transmitterTicks"`
+	Value                 int        `json:"value"`
+	Trend                 TrendArrow `json:"trend"`
+	TrendRate             float64    `json:"trendRate"`
+	Unit                  string     `json:"unit"`
+	RateUnit              string     `json:"rateUnit"`
+	DisplayDevice         string     `json:"displayDevice"`
+	TransmitterGeneration string     `json:"transmitterGeneration"`
+	DisplayApp            string     `json:"displayApp"`
+}
+
+// EventType categorizes Dexcom-logged events.
+type EventType string
+
+const (
+	EventTypeCarbs    EventType = "carbs"
+	EventTypeInsulin  EventType = "insulin"
+	EventTypeExercise EventType = "exercise"
+	EventTypeHealth   EventType = "health"
+)
+
+// DexcomEvent is a carbs/insulin/exercise/health event from the Dexcom API.
+type DexcomEvent struct {
+	RecordID     string    `json:"recordId"`
+	SystemTime   time.Time `json:"systemTime"`
+	DisplayTime  time.Time `json:"displayTime"`
+	EventType    EventType `json:"eventType"`
+	EventSubType *string   `json:"eventSubType,omitempty"`
+	Value        *float64  `json:"value,omitempty"`
+	Unit         string    `json:"unit"`
+}
+
+// TimeRange is a start/end timestamp pair from the Dexcom dataRange endpoint.
+type TimeRange struct {
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+}
+
+// DataRange holds the earliest/latest record timestamps per data type.
+type DataRange struct {
+	Calibrations TimeRange `json:"calibrations"`
+	EGVs         TimeRange `json:"egvs"`
+	Events       TimeRange `json:"events"`
+}
+
+// OAuthTokens holds Dexcom OAuth credentials.
+// refresh_token is single-use: every successful token refresh issues a new one.
+// The old refresh_token is immediately invalidated by Dexcom.
+type OAuthTokens struct {
+	AccessToken   string    `json:"access_token"`
+	RefreshToken  string    `json:"refresh_token"`
+	ExpiresAt     time.Time `json:"expires_at"`
+	LastRefreshed time.Time `json:"last_refreshed"`
+}
+
+// --- Application Types ---
+
+// ExerciseIntensity represents perceived exertion for an exercise session.
+type ExerciseIntensity string
+
+const (
+	IntensityLow          ExerciseIntensity = "low"
+	IntensityModerate     ExerciseIntensity = "moderate"
+	IntensityModerateHigh ExerciseIntensity = "moderate_high"
+	IntensityHigh         ExerciseIntensity = "high"
+	IntensityMax          ExerciseIntensity = "max"
+)
+
+// Meal is a locally stored meal record.
+type Meal struct {
+	ID          string   `json:"id"`
+	Description string   `json:"description"`
+	CarbsEst    *float64 `json:"carbs_est,omitempty"`
+	ProteinEst  *float64 `json:"protein_est,omitempty"`
+	FatEst      *float64 `json:"fat_est,omitempty"`
+	Timestamp   time.Time `json:"timestamp"`
+	LoggedAt    time.Time `json:"logged_at"`
+	Notes       *string  `json:"notes,omitempty"`
+}
+
+// Exercise is a locally stored exercise session record.
+type Exercise struct {
+	ID          string            `json:"id"`
+	Type        string            `json:"type"`
+	DurationMin int               `json:"duration_min"`
+	Intensity   ExerciseIntensity `json:"intensity"`
+	Timestamp   time.Time         `json:"timestamp"`
+	LoggedAt    time.Time         `json:"logged_at"`
+	Notes       *string           `json:"notes,omitempty"`
+}
+
+// GlucoseSnapshot is the structured response for get_current_glucose and get_glucose_history.
+// History is always sorted ascending by SystemTime.
+type GlucoseSnapshot struct {
+	Current         EGVRecord   `json:"current"`
+	Baseline        *EGVRecord  `json:"baseline,omitempty"`
+	Peak            *EGVRecord  `json:"peak,omitempty"`
+	Trough          *EGVRecord  `json:"trough,omitempty"`
+	History         []EGVRecord `json:"history"`
+	DataDelayNotice *string     `json:"data_delay_notice,omitempty"`
+}
+
+// ExerciseOffset describes glucose changes during exercise within the post-meal window.
+type ExerciseOffset struct {
+	Exercise       Exercise `json:"exercise"`
+	GlucoseAtStart int      `json:"glucose_at_start"`
+	GlucoseAtEnd   int      `json:"glucose_at_end"`
+	Delta          int      `json:"delta"`
+	Effectiveness  string   `json:"effectiveness"`
+}
+
+// MealImpactAssessment is the structured output from rate_meal_impact.
+type MealImpactAssessment struct {
+	Meal            Meal            `json:"meal"`
+	PreMealGlucose  int             `json:"pre_meal_glucose"`
+	PeakGlucose     int             `json:"peak_glucose"`
+	SpikeDelta      int             `json:"spike_delta"`
+	TimeToPeakMin   int             `json:"time_to_peak_min"`
+	RecoveryGlucose int             `json:"recovery_glucose"`
+	RecoveryTimeMin *int            `json:"recovery_time_min,omitempty"`
+	ExerciseOffset  *ExerciseOffset `json:"exercise_offset,omitempty"`
+	Rating          int             `json:"rating"`
+	RatingRationale string          `json:"rating_rationale"`
+}
+
+// --- ID Helpers ---
+
+// MealID generates a Meal ID from the meal's consumption timestamp.
+// Format: m_YYYYMMDD_HHmm (UTC). Always derived from Timestamp, not LoggedAt.
+func MealID(t time.Time) string {
+	return "m_" + t.UTC().Format("20060102_1504")
+}
+
+// ExerciseID generates an Exercise ID from the session start timestamp.
+// Format: e_YYYYMMDD_HHmm (UTC). Always derived from Timestamp, not LoggedAt.
+func ExerciseID(t time.Time) string {
+	return "e_" + t.UTC().Format("20060102_1504")
+}

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -1,0 +1,50 @@
+package types_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/johnmartinez/cgm-get-agent/internal/types"
+)
+
+func TestMealID_Format(t *testing.T) {
+	ts := time.Date(2026, 3, 3, 12, 15, 0, 0, time.UTC)
+	id := types.MealID(ts)
+	if id != "m_20260303_1215" {
+		t.Errorf("MealID: expected %q, got %q", "m_20260303_1215", id)
+	}
+	if !strings.HasPrefix(id, "m_") {
+		t.Errorf("MealID must start with m_, got %q", id)
+	}
+}
+
+func TestExerciseID_Format(t *testing.T) {
+	ts := time.Date(2026, 3, 3, 14, 30, 0, 0, time.UTC)
+	id := types.ExerciseID(ts)
+	if id != "e_20260303_1430" {
+		t.Errorf("ExerciseID: expected %q, got %q", "e_20260303_1430", id)
+	}
+	if !strings.HasPrefix(id, "e_") {
+		t.Errorf("ExerciseID must start with e_, got %q", id)
+	}
+}
+
+func TestMealID_UsesUTC(t *testing.T) {
+	// A non-UTC time should still produce a UTC-based ID.
+	loc, _ := time.LoadLocation("America/Los_Angeles")
+	ts := time.Date(2026, 3, 3, 4, 0, 0, 0, loc) // 04:00 PT = 12:00 UTC
+	id := types.MealID(ts)
+	if id != "m_20260303_1200" {
+		t.Errorf("MealID must use UTC: expected %q, got %q", "m_20260303_1200", id)
+	}
+}
+
+func TestExerciseID_UsesUTC(t *testing.T) {
+	loc, _ := time.LoadLocation("America/Los_Angeles")
+	ts := time.Date(2026, 3, 3, 7, 30, 0, 0, loc) // 07:30 PT = 15:30 UTC
+	id := types.ExerciseID(ts)
+	if id != "e_20260303_1530" {
+		t.Errorf("ExerciseID must use UTC: expected %q, got %q", "e_20260303_1530", id)
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/types` — all shared structs (EGVRecord, Meal, Exercise, GlucoseSnapshot, OAuthTokens, etc.) and ID helpers
- `internal/config` — YAML + `GA_*` env var loading, fail-fast validation, glucose zone defaults
- `internal/crypto` — AES-256-GCM encrypt/decrypt (stdlib only), atomic token file write via tmp→rename
- `internal/store` — `Store` struct with versioned migrations, Meal CRUD, Exercise CRUD, EGV cache upsert/query

## Test plan
- [x] 30 tests across all 4 packages
- [x] `go test -race ./internal/...` — all pass
- [x] `go vet ./...` — clean
- [x] Crypto: round-trip, wrong-key rejection, tamper detection, atomic write, directory creation
- [x] Config: missing required fields, env wins over YAML, YAML wins over defaults, invalid key formats
- [x] Store: meal/exercise CRUD, time-range filtering, cache upsert dedup, full field round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)