### PR TITLE
feat(analyzer): glucose zone classifier, snapshot builder, meal impact assessment

### DIFF
--- a/internal/analyzer/glucose.go
+++ b/internal/analyzer/glucose.go
@@ -1,0 +1,318 @@
+// Package analyzer implements pure business logic for glucose zone classification,
+// snapshot construction, and meal impact assessment. It has no I/O side effects
+// and no external dependencies beyond the project's own types and config packages.
+package analyzer
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/johnmartinez/cgm-get-agent/internal/config"
+	"github.com/johnmartinez/cgm-get-agent/internal/types"
+)
+
+// dataDelayThreshold is the maximum age of the most-recent EGV before a
+// data_delay_notice is included in the snapshot.
+const dataDelayThreshold = 10 * time.Minute
+
+// postMealWindowStart is the minimum number of minutes after meal time before
+// the post-meal glucose window begins.
+const postMealWindowStart = 30 * time.Minute
+
+// postMealWindowEnd is the maximum number of minutes after meal time before
+// the post-meal glucose window ends.
+const postMealWindowEnd = 180 * time.Minute
+
+// ClassifyZone maps a glucose value (mg/dL) to a named zone using the provided
+// threshold configuration. Zones are:
+//
+//	"low"        — below Low threshold
+//	"low_normal" — at or above Low, below TargetLow
+//	"target"     — at or above TargetLow, below or equal to TargetHigh
+//	"elevated"   — above TargetHigh, below High
+//	"high"       — at or above High
+func ClassifyZone(value int, zones config.GlucoseZones) string {
+	switch {
+	case value < zones.Low:
+		return "low"
+	case value < zones.TargetLow:
+		return "low_normal"
+	case value <= zones.TargetHigh:
+		return "target"
+	case value < zones.High:
+		return "elevated"
+	default:
+		return "high"
+	}
+}
+
+// ComputeSnapshot builds a GlucoseSnapshot from a slice of EGV records.
+// It returns an error if egvs is empty.
+//
+// Behavior:
+//   - History is sorted ascending by SystemTime.
+//   - Current = last record (most recent after sort).
+//   - Baseline = first record (oldest after sort).
+//   - Peak = record with the highest Value.
+//   - Trough = record with the lowest Value.
+//   - DataDelayNotice is set when the most recent EGV's SystemTime is more
+//     than 10 minutes before now (using time.Now().UTC()).
+func ComputeSnapshot(egvs []types.EGVRecord, zones config.GlucoseZones) (types.GlucoseSnapshot, error) {
+	if len(egvs) == 0 {
+		return types.GlucoseSnapshot{}, fmt.Errorf("analyzer: no EGV records provided")
+	}
+
+	sorted := make([]types.EGVRecord, len(egvs))
+	copy(sorted, egvs)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].SystemTime.Before(sorted[j].SystemTime)
+	})
+
+	current := sorted[len(sorted)-1]
+	baseline := sorted[0]
+
+	peak := sorted[0]
+	trough := sorted[0]
+	for _, r := range sorted[1:] {
+		if r.Value > peak.Value {
+			peak = r
+		}
+		if r.Value < trough.Value {
+			trough = r
+		}
+	}
+
+	snap := types.GlucoseSnapshot{
+		Current:  current,
+		Baseline: &baseline,
+		Peak:     &peak,
+		Trough:   &trough,
+		History:  sorted,
+	}
+
+	age := time.Now().UTC().Sub(current.SystemTime)
+	if age > dataDelayThreshold {
+		msg := fmt.Sprintf("most recent reading is %.0f minutes old; CGM data may be delayed", age.Minutes())
+		snap.DataDelayNotice = &msg
+	}
+
+	return snap, nil
+}
+
+// AssessMealImpact computes a MealImpactAssessment for a logged meal using
+// the EGV history surrounding the meal timestamp.
+//
+// Post-meal window: 30–180 minutes after meal.Timestamp.
+// Pre-meal baseline: the EGV record closest to (and at or before) meal.Timestamp.
+//
+// Returns an error when:
+//   - No EGVs are provided.
+//   - No pre-meal baseline EGV is found at or before meal.Timestamp.
+//   - No post-meal EGVs are found in the 30–180 minute window.
+func AssessMealImpact(meal types.Meal, egvs []types.EGVRecord, exercises []types.Exercise) (types.MealImpactAssessment, error) {
+	if len(egvs) == 0 {
+		return types.MealImpactAssessment{}, fmt.Errorf("analyzer: no EGV records provided for meal impact assessment")
+	}
+
+	sorted := make([]types.EGVRecord, len(egvs))
+	copy(sorted, egvs)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].SystemTime.Before(sorted[j].SystemTime)
+	})
+
+	mealTime := meal.Timestamp.UTC()
+	windowStart := mealTime.Add(postMealWindowStart)
+	windowEnd := mealTime.Add(postMealWindowEnd)
+
+	// Find the pre-meal baseline: the latest EGV at or before meal time.
+	preMealIdx := -1
+	for i, r := range sorted {
+		if !r.SystemTime.After(mealTime) {
+			preMealIdx = i
+		}
+	}
+	if preMealIdx == -1 {
+		return types.MealImpactAssessment{}, fmt.Errorf("analyzer: no pre-meal EGV found at or before meal time %v", mealTime)
+	}
+	preMealRecord := sorted[preMealIdx]
+
+	// Collect post-meal EGVs.
+	var postMealEGVs []types.EGVRecord
+	for _, r := range sorted {
+		t := r.SystemTime
+		if !t.Before(windowStart) && !t.After(windowEnd) {
+			postMealEGVs = append(postMealEGVs, r)
+		}
+	}
+	if len(postMealEGVs) == 0 {
+		return types.MealImpactAssessment{}, fmt.Errorf("analyzer: no post-meal EGVs found in 30–180 minute window after %v", mealTime)
+	}
+
+	// Find peak and recovery (last value in window) from post-meal EGVs.
+	peakRecord := postMealEGVs[0]
+	for _, r := range postMealEGVs[1:] {
+		if r.Value > peakRecord.Value {
+			peakRecord = r
+		}
+	}
+	recoveryRecord := postMealEGVs[len(postMealEGVs)-1]
+
+	spikeDelta := peakRecord.Value - preMealRecord.Value
+	if spikeDelta < 0 {
+		spikeDelta = 0
+	}
+
+	timeToPeakMin := int(peakRecord.SystemTime.Sub(mealTime).Minutes())
+
+	rating := rateSpike(spikeDelta)
+	rationale := buildRationale(spikeDelta, rating, preMealRecord.Value, peakRecord.Value)
+
+	assessment := types.MealImpactAssessment{
+		Meal:            meal,
+		PreMealGlucose:  preMealRecord.Value,
+		PeakGlucose:     peakRecord.Value,
+		SpikeDelta:      spikeDelta,
+		TimeToPeakMin:   timeToPeakMin,
+		RecoveryGlucose: recoveryRecord.Value,
+		Rating:          rating,
+		RatingRationale: rationale,
+	}
+
+	// Compute recovery time: first post-meal EGV that returns to pre-meal level.
+	for _, r := range postMealEGVs {
+		if r.Value <= preMealRecord.Value {
+			mins := int(r.SystemTime.Sub(mealTime).Minutes())
+			assessment.RecoveryTimeMin = &mins
+			break
+		}
+	}
+
+	// Check for exercise in the post-meal window.
+	offset := findExerciseOffset(exercises, mealTime, windowEnd, sorted)
+	if offset != nil {
+		assessment.ExerciseOffset = offset
+	}
+
+	return assessment, nil
+}
+
+// rateSpike maps spike_delta (mg/dL) to a 1–10 rating per the spec table.
+func rateSpike(delta int) int {
+	switch {
+	case delta <= 20:
+		return 10
+	case delta <= 30:
+		return 9
+	case delta <= 40:
+		return 8
+	case delta <= 50:
+		return 7
+	case delta <= 60:
+		return 6
+	case delta <= 70:
+		return 5
+	case delta <= 80:
+		return 4
+	case delta <= 100:
+		return 3
+	case delta <= 120:
+		return 2
+	default:
+		return 1
+	}
+}
+
+// buildRationale constructs a human-readable rating explanation.
+func buildRationale(spikeDelta, rating, preMeal, peak int) string {
+	return fmt.Sprintf(
+		"glucose rose %d mg/dL (from %d to %d); spike rating %d/10 (%s)",
+		spikeDelta, preMeal, peak, rating, ratingLabel(rating),
+	)
+}
+
+func ratingLabel(rating int) string {
+	switch {
+	case rating >= 9:
+		return "excellent"
+	case rating >= 7:
+		return "good"
+	case rating >= 5:
+		return "moderate"
+	case rating >= 3:
+		return "high"
+	default:
+		return "very high"
+	}
+}
+
+// findExerciseOffset returns an ExerciseOffset if any exercise session overlaps
+// the post-meal window (mealTime to windowEnd). It picks the EGV records closest
+// to exercise start and end to compute the glucose delta during exercise.
+func findExerciseOffset(exercises []types.Exercise, mealTime, windowEnd time.Time, sortedEGVs []types.EGVRecord) *types.ExerciseOffset {
+	for _, ex := range exercises {
+		exStart := ex.Timestamp.UTC()
+		exEnd := exStart.Add(time.Duration(ex.DurationMin) * time.Minute)
+
+		// Exercise must overlap the post-meal window.
+		if exEnd.Before(mealTime) || exStart.After(windowEnd) {
+			continue
+		}
+
+		glucoseAtStart := closestEGVValue(sortedEGVs, exStart)
+		glucoseAtEnd := closestEGVValue(sortedEGVs, exEnd)
+		if glucoseAtStart == 0 || glucoseAtEnd == 0 {
+			continue
+		}
+
+		delta := glucoseAtEnd - glucoseAtStart
+		effectiveness := exerciseEffectiveness(delta)
+
+		return &types.ExerciseOffset{
+			Exercise:       ex,
+			GlucoseAtStart: glucoseAtStart,
+			GlucoseAtEnd:   glucoseAtEnd,
+			Delta:          delta,
+			Effectiveness:  effectiveness,
+		}
+	}
+	return nil
+}
+
+// closestEGVValue returns the Value of the EGV record whose SystemTime is
+// nearest to t. Returns 0 if sortedEGVs is empty.
+func closestEGVValue(sortedEGVs []types.EGVRecord, t time.Time) int {
+	if len(sortedEGVs) == 0 {
+		return 0
+	}
+	best := sortedEGVs[0]
+	bestDiff := absDuration(sortedEGVs[0].SystemTime.Sub(t))
+	for _, r := range sortedEGVs[1:] {
+		d := absDuration(r.SystemTime.Sub(t))
+		if d < bestDiff {
+			bestDiff = d
+			best = r
+		}
+	}
+	return best.Value
+}
+
+func absDuration(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	}
+	return d
+}
+
+func exerciseEffectiveness(delta int) string {
+	switch {
+	case delta < -20:
+		return "strong_reduction"
+	case delta < 0:
+		return "mild_reduction"
+	case delta == 0:
+		return "neutral"
+	default:
+		return "no_reduction"
+	}
+}

--- a/internal/analyzer/glucose_test.go
+++ b/internal/analyzer/glucose_test.go
@@ -1,0 +1,418 @@
+package analyzer
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/johnmartinez/cgm-get-agent/internal/config"
+	"github.com/johnmartinez/cgm-get-agent/internal/types"
+)
+
+// defaultZones returns the same defaults used by config.Load().
+func defaultZones() config.GlucoseZones {
+	return config.GlucoseZones{
+		Low:        70,
+		TargetLow:  80,
+		TargetHigh: 120,
+		Elevated:   140,
+		High:       180,
+	}
+}
+
+// makeEGV builds a minimal EGVRecord at the given offset from base.
+func makeEGV(base time.Time, offsetMin int, value int) types.EGVRecord {
+	t := base.Add(time.Duration(offsetMin) * time.Minute)
+	return types.EGVRecord{
+		RecordID:   strings.ReplaceAll(t.Format("T150405"), ":", ""),
+		SystemTime: t,
+		Value:      value,
+		Trend:      types.TrendFlat,
+	}
+}
+
+// --- ClassifyZone ---
+
+func TestClassifyZone_AllZones(t *testing.T) {
+	zones := defaultZones()
+	cases := []struct {
+		value int
+		want  string
+	}{
+		{40, "low"},
+		{69, "low"},
+		{70, "low_normal"}, // equal to Low — first non-low zone
+		{79, "low_normal"},
+		{80, "target"},    // equal to TargetLow
+		{100, "target"},
+		{120, "target"},   // equal to TargetHigh — still target
+		{121, "elevated"},
+		{139, "elevated"},
+		{179, "elevated"}, // just below High
+		{180, "high"},     // equal to High
+		{250, "high"},
+	}
+	for _, tc := range cases {
+		got := ClassifyZone(tc.value, zones)
+		if got != tc.want {
+			t.Errorf("ClassifyZone(%d) = %q, want %q", tc.value, got, tc.want)
+		}
+	}
+}
+
+func TestClassifyZone_BoundaryValues(t *testing.T) {
+	zones := defaultZones()
+
+	// One below each threshold boundary.
+	if got := ClassifyZone(zones.Low-1, zones); got != "low" {
+		t.Errorf("one below Low: got %q, want low", got)
+	}
+	if got := ClassifyZone(zones.TargetLow-1, zones); got != "low_normal" {
+		t.Errorf("one below TargetLow: got %q, want low_normal", got)
+	}
+	if got := ClassifyZone(zones.TargetHigh, zones); got != "target" {
+		t.Errorf("TargetHigh itself: got %q, want target", got)
+	}
+	if got := ClassifyZone(zones.TargetHigh+1, zones); got != "elevated" {
+		t.Errorf("one above TargetHigh: got %q, want elevated", got)
+	}
+	if got := ClassifyZone(zones.High-1, zones); got != "elevated" {
+		t.Errorf("one below High: got %q, want elevated", got)
+	}
+	if got := ClassifyZone(zones.High, zones); got != "high" {
+		t.Errorf("High itself: got %q, want high", got)
+	}
+}
+
+// --- ComputeSnapshot ---
+
+func TestComputeSnapshot_Empty(t *testing.T) {
+	_, err := ComputeSnapshot(nil, defaultZones())
+	if err == nil {
+		t.Fatal("expected error for empty EGV slice")
+	}
+}
+
+func TestComputeSnapshot_SingleRecord(t *testing.T) {
+	base := time.Now().UTC().Add(-5 * time.Minute) // recent enough — no delay notice
+	egvs := []types.EGVRecord{makeEGV(base, 0, 105)}
+
+	snap, err := ComputeSnapshot(egvs, defaultZones())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap.Current.Value != 105 {
+		t.Errorf("Current.Value = %d, want 105", snap.Current.Value)
+	}
+	if snap.Baseline.Value != 105 {
+		t.Errorf("Baseline.Value = %d, want 105", snap.Baseline.Value)
+	}
+	if snap.Peak.Value != 105 {
+		t.Errorf("Peak.Value = %d, want 105", snap.Peak.Value)
+	}
+	if snap.Trough.Value != 105 {
+		t.Errorf("Trough.Value = %d, want 105", snap.Trough.Value)
+	}
+	if snap.DataDelayNotice != nil {
+		t.Errorf("unexpected DataDelayNotice for recent EGV: %q", *snap.DataDelayNotice)
+	}
+}
+
+func TestComputeSnapshot_HistorySortedAscending(t *testing.T) {
+	base := time.Now().UTC().Add(-20 * time.Minute)
+	// Provide out-of-order records.
+	egvs := []types.EGVRecord{
+		makeEGV(base, 10, 115),
+		makeEGV(base, 0, 100),
+		makeEGV(base, 5, 110),
+	}
+	snap, err := ComputeSnapshot(egvs, defaultZones())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := 1; i < len(snap.History); i++ {
+		if snap.History[i].SystemTime.Before(snap.History[i-1].SystemTime) {
+			t.Errorf("history not sorted ascending at index %d", i)
+		}
+	}
+	if snap.Current.Value != 115 {
+		t.Errorf("Current should be most recent (115), got %d", snap.Current.Value)
+	}
+	if snap.Baseline.Value != 100 {
+		t.Errorf("Baseline should be oldest (100), got %d", snap.Baseline.Value)
+	}
+}
+
+func TestComputeSnapshot_PeakAndTrough(t *testing.T) {
+	base := time.Now().UTC().Add(-60 * time.Minute)
+	egvs := []types.EGVRecord{
+		makeEGV(base, 0, 90),
+		makeEGV(base, 5, 160),
+		makeEGV(base, 10, 70),
+		makeEGV(base, 15, 110),
+	}
+	snap, err := ComputeSnapshot(egvs, defaultZones())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap.Peak.Value != 160 {
+		t.Errorf("Peak = %d, want 160", snap.Peak.Value)
+	}
+	if snap.Trough.Value != 70 {
+		t.Errorf("Trough = %d, want 70", snap.Trough.Value)
+	}
+}
+
+func TestComputeSnapshot_DataDelayNotice_TriggeredAtTenMinPlusOne(t *testing.T) {
+	// EGV is exactly 10 min + 1 sec old — must trigger notice.
+	staleTime := time.Now().UTC().Add(-(dataDelayThreshold + time.Second))
+	egvs := []types.EGVRecord{
+		{RecordID: "stale", SystemTime: staleTime, Value: 100},
+	}
+	snap, err := ComputeSnapshot(egvs, defaultZones())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap.DataDelayNotice == nil {
+		t.Error("expected DataDelayNotice for EGV older than 10 minutes")
+	}
+}
+
+func TestComputeSnapshot_DataDelayNotice_NotTriggeredBeforeTenMin(t *testing.T) {
+	// EGV is 9 min 59 sec old — must NOT trigger notice.
+	recentTime := time.Now().UTC().Add(-(dataDelayThreshold - time.Second))
+	egvs := []types.EGVRecord{
+		{RecordID: "recent", SystemTime: recentTime, Value: 100},
+	}
+	snap, err := ComputeSnapshot(egvs, defaultZones())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap.DataDelayNotice != nil {
+		t.Errorf("DataDelayNotice should not fire before 10 min threshold: %q", *snap.DataDelayNotice)
+	}
+}
+
+// --- AssessMealImpact ---
+
+// buildMealEGVs creates a synthetic EGV curve:
+// - 4 records before the meal (t-20 to t-5 min)
+// - preMeal value at t-5
+// - rising curve in post-meal window
+// - peak at +peakOffsetMin
+// - flat recovery at recoveryValue
+func buildMealEGVs(mealTime time.Time, preMeal, peak, recovery, peakOffsetMin int) []types.EGVRecord {
+	egvs := []types.EGVRecord{
+		makeEGV(mealTime, -20, preMeal-5),
+		makeEGV(mealTime, -15, preMeal-3),
+		makeEGV(mealTime, -10, preMeal-1),
+		makeEGV(mealTime, -5, preMeal),
+		// post-meal: rising to peak then recovery
+		makeEGV(mealTime, 30, preMeal+10),
+		makeEGV(mealTime, peakOffsetMin, peak),
+		makeEGV(mealTime, 120, recovery),
+		makeEGV(mealTime, 150, recovery),
+		makeEGV(mealTime, 180, recovery),
+	}
+	return egvs
+}
+
+func makeMeal(t time.Time) types.Meal {
+	return types.Meal{
+		ID:          types.MealID(t),
+		Description: "test meal",
+		Timestamp:   t,
+		LoggedAt:    t,
+	}
+}
+
+// TestAssessMealImpact_AllRatingTiers verifies each tier of the spike rating table.
+func TestAssessMealImpact_AllRatingTiers(t *testing.T) {
+	mealTime := time.Now().UTC().Add(-4 * time.Hour) // well in the past
+
+	cases := []struct {
+		spikeDelta int
+		wantRating int
+	}{
+		{20, 10},
+		{21, 9}, {30, 9},
+		{31, 8}, {40, 8},
+		{41, 7}, {50, 7},
+		{51, 6}, {60, 6},
+		{61, 5}, {70, 5},
+		{71, 4}, {80, 4},
+		{81, 3}, {100, 3},
+		{101, 2}, {120, 2},
+		{121, 1}, {200, 1},
+	}
+
+	for _, tc := range cases {
+		preMeal := 100
+		peak := preMeal + tc.spikeDelta
+		egvs := buildMealEGVs(mealTime, preMeal, peak, preMeal, 60)
+		meal := makeMeal(mealTime)
+
+		got, err := AssessMealImpact(meal, egvs, nil)
+		if err != nil {
+			t.Errorf("spike=%d: unexpected error: %v", tc.spikeDelta, err)
+			continue
+		}
+		if got.Rating != tc.wantRating {
+			t.Errorf("spike=%d: rating=%d, want %d", tc.spikeDelta, got.Rating, tc.wantRating)
+		}
+		if got.SpikeDelta != tc.spikeDelta {
+			t.Errorf("spike=%d: SpikeDelta=%d, want %d", tc.spikeDelta, got.SpikeDelta, tc.spikeDelta)
+		}
+	}
+}
+
+func TestAssessMealImpact_NoEGVs(t *testing.T) {
+	meal := makeMeal(time.Now().Add(-2 * time.Hour))
+	_, err := AssessMealImpact(meal, nil, nil)
+	if err == nil {
+		t.Fatal("expected error when no EGVs provided")
+	}
+}
+
+func TestAssessMealImpact_NoPreMealEGV(t *testing.T) {
+	mealTime := time.Now().UTC().Add(-3 * time.Hour)
+	// All EGVs are after the meal.
+	egvs := []types.EGVRecord{
+		makeEGV(mealTime, 35, 120),
+		makeEGV(mealTime, 60, 140),
+	}
+	meal := makeMeal(mealTime)
+	_, err := AssessMealImpact(meal, egvs, nil)
+	if err == nil {
+		t.Fatal("expected error when no pre-meal EGV found")
+	}
+}
+
+func TestAssessMealImpact_NoPostMealEGVs(t *testing.T) {
+	mealTime := time.Now().UTC().Add(-5 * time.Hour)
+	// EGVs only before the meal or outside the 30–180 min window.
+	egvs := []types.EGVRecord{
+		makeEGV(mealTime, -10, 100),
+		makeEGV(mealTime, 5, 105),   // within 30 min — not post-meal window
+		makeEGV(mealTime, 200, 110), // beyond 180 min
+	}
+	meal := makeMeal(mealTime)
+	_, err := AssessMealImpact(meal, egvs, nil)
+	if err == nil {
+		t.Fatal("expected error when no post-meal EGVs in window")
+	}
+}
+
+func TestAssessMealImpact_ExerciseOffset_InWindow(t *testing.T) {
+	mealTime := time.Now().UTC().Add(-5 * time.Hour)
+	preMeal := 100
+	peak := 150
+	egvs := buildMealEGVs(mealTime, preMeal, peak, preMeal, 60)
+
+	// Exercise starting 45 min after meal (within 30–180 min window).
+	exTime := mealTime.Add(45 * time.Minute)
+	exercises := []types.Exercise{
+		{
+			ID:          types.ExerciseID(exTime),
+			Type:        "walk",
+			DurationMin: 30,
+			Intensity:   types.IntensityModerate,
+			Timestamp:   exTime,
+			LoggedAt:    exTime,
+		},
+	}
+
+	meal := makeMeal(mealTime)
+	got, err := AssessMealImpact(meal, egvs, exercises)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ExerciseOffset == nil {
+		t.Error("expected ExerciseOffset to be populated for exercise in post-meal window")
+	}
+}
+
+func TestAssessMealImpact_ExerciseOffset_OutsideWindow(t *testing.T) {
+	mealTime := time.Now().UTC().Add(-8 * time.Hour)
+	preMeal := 100
+	peak := 130
+	egvs := buildMealEGVs(mealTime, preMeal, peak, preMeal, 60)
+
+	// Exercise 4 hours after meal — outside the 30–180 min post-meal window.
+	exTime := mealTime.Add(4 * time.Hour)
+	exercises := []types.Exercise{
+		{
+			ID:          types.ExerciseID(exTime),
+			Type:        "run",
+			DurationMin: 30,
+			Intensity:   types.IntensityHigh,
+			Timestamp:   exTime,
+			LoggedAt:    exTime,
+		},
+	}
+
+	meal := makeMeal(mealTime)
+	got, err := AssessMealImpact(meal, egvs, exercises)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ExerciseOffset != nil {
+		t.Error("ExerciseOffset should be nil for exercise outside post-meal window")
+	}
+}
+
+func TestAssessMealImpact_RatingRationale_NonEmpty(t *testing.T) {
+	mealTime := time.Now().UTC().Add(-4 * time.Hour)
+	egvs := buildMealEGVs(mealTime, 100, 140, 100, 60)
+	meal := makeMeal(mealTime)
+
+	got, err := AssessMealImpact(meal, egvs, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.RatingRationale == "" {
+		t.Error("RatingRationale must not be empty")
+	}
+}
+
+func TestAssessMealImpact_NegativeSpikeClampsToZero(t *testing.T) {
+	// If glucose drops after a meal (e.g. insulin), SpikeDelta must be 0, not negative.
+	mealTime := time.Now().UTC().Add(-4 * time.Hour)
+	egvs := []types.EGVRecord{
+		makeEGV(mealTime, -5, 120),
+		makeEGV(mealTime, 35, 100), // lower than pre-meal
+		makeEGV(mealTime, 60, 90),
+		makeEGV(mealTime, 90, 95),
+	}
+	meal := makeMeal(mealTime)
+
+	got, err := AssessMealImpact(meal, egvs, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.SpikeDelta < 0 {
+		t.Errorf("SpikeDelta must not be negative, got %d", got.SpikeDelta)
+	}
+}
+
+// --- rateSpike (internal) ---
+
+func TestRateSpike_AllTiers(t *testing.T) {
+	cases := []struct{ delta, want int }{
+		{0, 10}, {20, 10},
+		{21, 9}, {30, 9},
+		{31, 8}, {40, 8},
+		{41, 7}, {50, 7},
+		{51, 6}, {60, 6},
+		{61, 5}, {70, 5},
+		{71, 4}, {80, 4},
+		{81, 3}, {100, 3},
+		{101, 2}, {120, 2},
+		{121, 1}, {500, 1},
+	}
+	for _, tc := range cases {
+		if got := rateSpike(tc.delta); got != tc.want {
+			t.Errorf("rateSpike(%d) = %d, want %d", tc.delta, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **ClassifyZone** maps a mg/dL glucose value to one of five named zones (`low`, `low_normal`, `target`, `elevated`, `high`) using the configurable threshold struct.
- **ComputeSnapshot** sorts EGV history ascending, populates current/baseline/peak/trough pointers, and sets `data_delay_notice` when the most-recent reading is >10 minutes old.
- **AssessMealImpact** computes pre-meal baseline (latest EGV at/before meal time), peak in the 30–180 min post-meal window, spike delta, 10-tier rating, recovery time, and exercise offset when any exercise session overlaps the post-meal window.

## Test plan

- [x] `TestClassifyZone_AllZones` — 12 explicit value cases across all five zones
- [x] `TestClassifyZone_BoundaryValues` — exact threshold edges for all five zone transitions
- [x] `TestComputeSnapshot_Empty` — error on empty input
- [x] `TestComputeSnapshot_SingleRecord` — all fields populated from one record; no delay notice
- [x] `TestComputeSnapshot_HistorySortedAscending` — out-of-order input sorts correctly; current/baseline correct
- [x] `TestComputeSnapshot_PeakAndTrough` — peak/trough correctly identified across 4-record sequence
- [x] `TestComputeSnapshot_DataDelayNotice_TriggeredAtTenMinPlusOne` — notice fires at 10min+1sec
- [x] `TestComputeSnapshot_DataDelayNotice_NotTriggeredBeforeTenMin` — notice absent at 9min59sec
- [x] `TestAssessMealImpact_AllRatingTiers` — 19 spike-delta cases covering all 10 rating tiers
- [x] `TestAssessMealImpact_NoEGVs` / `NoPreMealEGV` / `NoPostMealEGVs` — error paths
- [x] `TestAssessMealImpact_ExerciseOffset_InWindow` — offset populated when exercise in window
- [x] `TestAssessMealImpact_ExerciseOffset_OutsideWindow` — offset nil when exercise outside window
- [x] `TestAssessMealImpact_RatingRationale_NonEmpty` — rationale string is non-empty
- [x] `TestAssessMealImpact_NegativeSpikeClampsToZero` — glucose drop after meal doesn't produce negative spike
- [x] `TestRateSpike_AllTiers` — exhaustive unit test of the rating table function

All 17 tests pass with `-race`. `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)