### PR TITLE
docs: add QUICKSTART and fix architecture diagram

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,248 @@
+# CGM Get Agent — Quick Start
+
+Connect your Dexcom G7 CGM to Claude Desktop or ChatGPT Desktop in about 15 minutes.
+
+---
+
+## What This Does
+
+CGM Get Agent runs as a local Docker container that exposes your Dexcom G7 data as MCP tools. Once connected, you can ask Claude or ChatGPT questions like:
+
+- *"What's my glucose right now and where is it headed?"*
+- *"I just had a bowl of oatmeal — log it and tell me what I'm starting from."*
+- *"How did that burrito I had at lunch hit me?"*
+- *"Did my CGM alarm go off last night?"*
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| macOS (Apple Silicon) | Intel Mac works with minor Dockerfile changes |
+| [Colima](https://github.com/abiosoft/colima) + Docker CLI | `brew install colima docker docker-compose` |
+| Dexcom G7 + iOS app | Active sensor and Dexcom cloud account required |
+| [Dexcom developer account](https://developer.dexcom.com) | Free to register |
+| Claude Desktop or ChatGPT Desktop | Any recent version with MCP support |
+
+---
+
+## Step 1 — Register a Dexcom Developer App
+
+1. Sign in at [developer.dexcom.com](https://developer.dexcom.com).
+2. Create a new application.
+3. Set the **Redirect URI** to: `http://localhost:8080/callback`
+4. Copy your **Client ID** and **Client Secret** — you'll need them in Step 3.
+
+> **Sandbox vs. Production**: The Dexcom sandbox provides simulated G7 data with no real CGM required. Start with sandbox (`GA_DEXCOM_ENV=sandbox`) to verify everything works, then switch to production for live readings.
+
+---
+
+## Step 2 — Install and Configure
+
+```bash
+# Clone the repo
+git clone https://github.com/johnmartinez/cgm-get-agent.git
+cd cgm-get-agent
+
+# Create the data directory
+mkdir -p ~/.cgm-get-agent
+chmod 700 ~/.cgm-get-agent
+
+# Copy and fill in the environment file
+cp .env.example .env
+```
+
+Edit `.env` with your values:
+
+```bash
+GA_DEXCOM_CLIENT_ID=your-client-id-from-dexcom
+GA_DEXCOM_CLIENT_SECRET=your-client-secret-from-dexcom
+GA_DEXCOM_ENV=sandbox          # or "production" for live CGM data
+GA_ENCRYPTION_KEY=$(openssl rand -hex 32)
+```
+
+> **Keep `.env` private.** It is gitignored and must never be committed.
+
+---
+
+## Step 3 — Start the Container
+
+```bash
+# Start Colima if it isn't already running
+colima start --arch aarch64 --vm-type vz
+
+# Build and start the agent
+docker compose up --build -d
+
+# Confirm it's healthy
+docker compose ps
+curl http://localhost:8080/health
+```
+
+Expected health response before OAuth:
+
+```json
+{"status":"degraded","dexcom_auth":"not_configured","db_accessible":true,"uptime_seconds":3}
+```
+
+---
+
+## Step 4 — Authorize Dexcom (One-Time)
+
+1. Open **http://localhost:8080/oauth/start** in your browser.
+2. Log in to your Dexcom account and complete the HIPAA authorization screen.
+3. You'll be redirected back with a success message.
+
+Verify authorization succeeded:
+
+```bash
+curl http://localhost:8080/health
+```
+
+```json
+{"status":"ok","dexcom_auth":"valid","db_accessible":true,"uptime_seconds":42}
+```
+
+OAuth tokens are encrypted with AES-256-GCM and stored at `~/.cgm-get-agent/tokens.enc`. They are never logged or sent anywhere except to Dexcom's API.
+
+---
+
+## Step 5 — Connect Claude Desktop
+
+Edit Claude Desktop's MCP config file:
+
+**`~/Library/Application Support/Claude/claude_desktop_config.json`**
+
+```json
+{
+  "mcpServers": {
+    "cgm-get-agent": {
+      "type": "sse",
+      "url": "http://localhost:8080/sse"
+    }
+  }
+}
+```
+
+Restart Claude Desktop. You should see **cgm-get-agent** appear in the tools panel (the hammer icon). The 11 tools will be listed there.
+
+> **Alternatively — stdio transport (Claude Code CLI only):**
+> ```bash
+> claude mcp add --transport sse cgm-get-agent http://localhost:8080/sse
+> ```
+> Or for stdio (runs a fresh server process per session):
+> ```bash
+> claude mcp add cgm-get-agent -- docker exec -e GA_MCP_TRANSPORT=stdio -i cgm-get-agent cgm-get-agent serve
+> ```
+
+---
+
+## Step 6 — Connect ChatGPT Desktop
+
+ChatGPT Desktop supports MCP via SSE. To add the server:
+
+1. Open **ChatGPT Desktop** → **Settings** → **Connectors** (or **MCP Servers**).
+2. Add a new server with URL: `http://localhost:8080/sse`
+3. Name it `cgm-get-agent`.
+4. Save and restart ChatGPT Desktop.
+
+The 11 tools will be available automatically in any conversation.
+
+> If your version of ChatGPT Desktop uses a config file instead of the UI, create or edit:
+> **`~/Library/Application Support/ChatGPT/mcp.json`**
+> ```json
+> {
+>   "servers": [
+>     {
+>       "name": "cgm-get-agent",
+>       "transport": "sse",
+>       "url": "http://localhost:8080/sse"
+>     }
+>   ]
+> }
+> ```
+
+---
+
+## Test It
+
+Try these prompts after connecting:
+
+```
+What's my glucose right now?
+```
+
+```
+I just had two slices of sourdough toast with peanut butter. Log it and show me my current trend.
+```
+
+```
+Did my Dexcom alarm go off at any point last night?
+```
+
+```
+How did the meal I logged at lunch impact my glucose? Give it a rating.
+```
+
+---
+
+## Available Tools
+
+| Tool | Description |
+|---|---|
+| `get_current_glucose` | Current reading + trend + optional history window |
+| `get_glucose_history` | Historical EGVs for a date range (max 30 days) |
+| `get_trend` | Trend arrow, rate of change, and glucose zone |
+| `get_dexcom_events` | Events logged in the G7 app (carbs, insulin, exercise, health) |
+| `get_calibrations` | Fingerstick calibration records |
+| `get_alerts` | CGM alert history (high, low, urgent low, rise, fall, etc.) |
+| `get_devices` | G7 transmitter and display device info |
+| `get_data_range` | Earliest/latest timestamps for each data type |
+| `log_meal` | Log a meal locally with optional macro estimates |
+| `log_exercise` | Log an exercise session locally |
+| `rate_meal_impact` | Analyze glucose impact of a logged meal (1–10 rating) |
+
+---
+
+## Troubleshooting
+
+**Health shows `dexcom_auth: not_configured`**
+Visit `http://localhost:8080/oauth/start` and complete the Dexcom authorization flow.
+
+**Health shows `dexcom_auth: expired`**
+Your refresh token expired (rare). Re-authorize: `open http://localhost:8080/oauth/start`
+
+**Tools show stale data notice**
+Normal for US mobile users — the Dexcom cloud has a ~1 hour delay for G7 data uploaded via iOS. Data uploaded from a Dexcom receiver via USB arrives immediately.
+
+**Container won't start**
+```bash
+docker compose logs cgm-get-agent
+```
+Most common cause: missing or incorrect values in `.env`.
+
+**Restart after reboot**
+```bash
+colima start --arch aarch64 --vm-type vz
+docker compose up -d
+```
+
+---
+
+## Switching to Production
+
+When you're ready to use live CGM data:
+
+1. Register a **production** app at [developer.dexcom.com](https://developer.dexcom.com) with redirect URI `http://localhost:8080/callback`.
+2. Update `.env`:
+   ```bash
+   GA_DEXCOM_CLIENT_ID=your-production-client-id
+   GA_DEXCOM_CLIENT_SECRET=your-production-client-secret
+   GA_DEXCOM_ENV=production
+   ```
+3. Restart and re-authorize:
+   ```bash
+   docker compose up --build -d
+   open http://localhost:8080/oauth/start
+   ```

--- a/docs/architecture.mermaid
+++ b/docs/architecture.mermaid
@@ -4,8 +4,8 @@ title: "CGM Get Agent — System Architecture"
 graph TB
     subgraph clients["CLIENT LAYER"]
         direction LR
-        claude["Claude<br/>(claude.ai / Claude Code)"]
-        chatgpt["ChatGPT<br/>(OpenAI API)"]
+        claude["Claude<br/>(Claude Desktop / Claude Code)"]
+        chatgpt["ChatGPT<br/>(ChatGPT Desktop)"]
     end
 
     subgraph docker["DOCKER (Colima / arm64)"]
@@ -16,17 +16,22 @@ graph TB
 
             subgraph transport["Transport Layer"]
                 mcp_handler["MCP Protocol Handler<br/>(SSE + stdio)"]
-                rest_shim["REST Shim<br/>(OpenAI Function Calling Adapter)"]
+                rest_shim["REST Shim<br/>(POST /v1/tools/invoke, GET /health)"]
             end
 
-            subgraph router["Tool Router"]
+            subgraph router["Tool Router (11 tools)"]
                 direction LR
                 t1["get_current_glucose"]
                 t2["get_glucose_history"]
                 t3["get_trend"]
-                t4["log_meal"]
-                t5["log_exercise"]
-                t6["rate_meal_impact"]
+                t4["get_dexcom_events"]
+                t5["get_calibrations"]
+                t6["get_alerts"]
+                t7["get_devices"]
+                t8["get_data_range"]
+                t9["log_meal"]
+                t10["log_exercise"]
+                t11["rate_meal_impact"]
             end
 
             subgraph core["Core Services"]
@@ -54,9 +59,11 @@ graph TB
 
     subgraph dexcom["DEXCOM DEVELOPER PLATFORM"]
         direction TB
-        dex_auth["OAuth2 Endpoints<br/>POST /v3/oauth2/login<br/>POST /v3/oauth2/token"]
+        dex_auth["OAuth2 Endpoints<br/>GET /v3/oauth2/login (auth redirect)<br/>POST /v3/oauth2/token (token exchange)"]
         dex_egvs["GET /v3/users/self/egvs<br/>(EGV + trend + trendRate)"]
         dex_events["GET /v3/users/self/events<br/>(carbs, exercise, health)"]
+        dex_calibrations["GET /v3/users/self/calibrations<br/>(fingerstick records)"]
+        dex_alerts["GET /v3/users/self/alerts<br/>(high/low/urgentLow/rise/fall)"]
         dex_range["GET /v3/users/self/dataRange<br/>(earliest/latest records)"]
         dex_devices["GET /v3/users/self/devices<br/>(G7 device info)"]
     end
@@ -67,22 +74,29 @@ graph TB
     end
 
     %% Client connections
-    claude -->|"MCP/SSE<br/>localhost:8080/mcp"| mcp_handler
-    chatgpt -->|"REST/JSON<br/>localhost:8080/v1/tools/*"| rest_shim
+    claude -->|"MCP/SSE<br/>localhost:8080/sse"| mcp_handler
+    chatgpt -->|"MCP/SSE<br/>localhost:8080/sse"| mcp_handler
 
     %% Transport to router
     mcp_handler --> router
     rest_shim --> router
 
-    %% Router to services
+    %% Router to services — Dexcom read tools
     t1 --> dexcom_client
     t2 --> dexcom_client
     t3 --> dexcom_client
-    t4 --> store
-    t5 --> store
+    t4 --> dexcom_client
+    t5 --> dexcom_client
     t6 --> dexcom_client
-    t6 --> store
-    t6 --> analyzer
+    t7 --> dexcom_client
+    t8 --> dexcom_client
+
+    %% Router to services — local tools
+    t9 --> store
+    t10 --> store
+    t11 --> dexcom_client
+    t11 --> store
+    t11 --> analyzer
 
     %% Core interconnections
     dexcom_client --> oauth
@@ -96,6 +110,8 @@ graph TB
     %% External connections
     dexcom_client -->|"HTTPS<br/>(Bearer token)"| dex_egvs
     dexcom_client -->|"HTTPS"| dex_events
+    dexcom_client -->|"HTTPS"| dex_calibrations
+    dexcom_client -->|"HTTPS"| dex_alerts
     dexcom_client -->|"HTTPS"| dex_range
     dexcom_client -->|"HTTPS"| dex_devices
     oauth -->|"HTTPS<br/>(OAuth2 grant)"| dex_auth
@@ -114,7 +130,7 @@ graph TB
 
     class claude,chatgpt clientNode
     class mcp_handler,rest_shim,dexcom_client,analyzer,oauth,config,crypto containerNode
-    class dex_auth,dex_egvs,dex_events,dex_range,dex_devices dexcomNode
+    class dex_auth,dex_egvs,dex_events,dex_calibrations,dex_alerts,dex_range,dex_devices dexcomNode
     class g7,phone cgmNode
     class db,tokens,cfg storageNode
-    class t1,t2,t3,t4,t5,t6 toolNode
+    class t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11 toolNode


### PR DESCRIPTION
## Summary

- **QUICKSTART.md** — new end-to-end guide for using the agent in Claude Desktop and ChatGPT Desktop; covers Dexcom app registration, `.env` setup, OAuth flow, MCP/SSE client config, tool reference table, troubleshooting, and production cutover
- **docs/architecture.mermaid** — 4 corrections vs. actual implementation:
  1. Tool Router now shows all 11 tools (diagram had only 6)
  2. Claude SSE URL corrected to `/sse` (was `/mcp`)
  3. Added missing Dexcom endpoints: `GET /calibrations` and `GET /alerts`
  4. Fixed `dex_auth` label: `GET /v3/oauth2/login` (redirect) + `POST /v3/oauth2/token` (was incorrectly `POST /v3/oauth2/login`)

## Test plan

- [ ] Render `docs/architecture.mermaid` and verify all 11 tools appear with correct connections
- [ ] Verify SSE URL shown as `localhost:8080/sse` in client connections
- [ ] Follow QUICKSTART.md steps end-to-end against a running container
- [ ] Confirm `claude_desktop_config.json` snippet works in Claude Desktop
- [ ] Confirm health endpoint JSON matches QUICKSTART examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)