### PR TITLE
fix(config): add GA_DEXCOM_REDIRECT_URI env override

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,6 +105,9 @@ func applyEnv(cfg *Config) {
 	if v := os.Getenv("GA_DEXCOM_ENV"); v != "" {
 		cfg.Dexcom.Environment = v
 	}
+	if v := os.Getenv("GA_DEXCOM_REDIRECT_URI"); v != "" {
+		cfg.Dexcom.RedirectURI = v
+	}
 	if v := os.Getenv("GA_SERVER_PORT"); v != "" {
 		if p, err := strconv.Atoi(v); err == nil {
 			cfg.Server.Port = p


### PR DESCRIPTION
## Summary
- `GA_DEXCOM_REDIRECT_URI` was missing from `applyEnv`, so the default `http://localhost:8080/callback` could not be overridden via `.env` or environment variable
- Added the missing env override alongside the other `GA_DEXCOM_*` vars in `applyEnv`

## Test plan
- [ ] Set `GA_DEXCOM_REDIRECT_URI=http://localhost:8090/callback` in `.env` and verify config loads with the correct URI
- [ ] Verify existing tests still pass: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)