### PR TITLE
docs: document port override env vars for port conflict scenarios

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,13 @@ GA_ENCRYPTION_KEY=replace-with-output-of-openssl-rand-hex-32
 # -------------------------------------------------------------------
 # GA_SERVER_PORT=8080
 # GA_MCP_TRANSPORT=sse
+
+# -------------------------------------------------------------------
+# Port conflict override
+# If port 8080 is already in use on your machine, override both vars
+# together so the server and the Dexcom redirect URI stay in sync.
+# You must also update your Dexcom developer app's Redirect URI to
+# match GA_DEXCOM_REDIRECT_URI.
+# -------------------------------------------------------------------
+# GA_SERVER_PORT=8090
+# GA_DEXCOM_REDIRECT_URI=http://localhost:8090/callback

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -32,6 +32,12 @@ CGM Get Agent runs as a local Docker container that exposes your Dexcom G7 data 
 1. Sign in at [developer.dexcom.com](https://developer.dexcom.com).
 2. Create a new application.
 3. Set the **Redirect URI** to: `http://localhost:8080/callback`
+   > **Using a different port?** If port 8080 is already in use on your machine, choose another port (e.g. 8090) and set the Redirect URI to `http://localhost:8090/callback` instead. Then add both overrides to `.env`:
+   > ```bash
+   > GA_SERVER_PORT=8090
+   > GA_DEXCOM_REDIRECT_URI=http://localhost:8090/callback
+   > ```
+   > The Dexcom developer portal Redirect URI and `GA_DEXCOM_REDIRECT_URI` must match exactly.
 4. Copy your **Client ID** and **Client Secret** — you'll need them in Step 3.
 
 > **Sandbox vs. Production**: The Dexcom sandbox provides simulated G7 data with no real CGM required. Start with sandbox (`GA_DEXCOM_ENV=sandbox`) to verify everything works, then switch to production for live readings.
@@ -216,6 +222,14 @@ Your refresh token expired (rare). Re-authorize: `open http://localhost:8080/oau
 **Tools show stale data notice**
 Normal for US mobile users — the Dexcom cloud has a ~1 hour delay for G7 data uploaded via iOS. Data uploaded from a Dexcom receiver via USB arrives immediately.
 
+**Port 8080 already in use**
+Set both port vars in `.env` and update your Dexcom app's Redirect URI to match:
+```bash
+GA_SERVER_PORT=8090
+GA_DEXCOM_REDIRECT_URI=http://localhost:8090/callback
+```
+Then replace every `8080` reference in this guide with your chosen port.
+
 **Container won't start**
 ```bash
 docker compose logs cgm-get-agent
@@ -234,7 +248,7 @@ docker compose up -d
 
 When you're ready to use live CGM data:
 
-1. Register a **production** app at [developer.dexcom.com](https://developer.dexcom.com) with redirect URI `http://localhost:8080/callback`.
+1. Register a **production** app at [developer.dexcom.com](https://developer.dexcom.com) with redirect URI matching `GA_DEXCOM_REDIRECT_URI` (default: `http://localhost:8080/callback`).
 2. Update `.env`:
    ```bash
    GA_DEXCOM_CLIENT_ID=your-production-client-id

--- a/README.md
+++ b/README.md
@@ -96,11 +96,18 @@ Now ask Claude: *"What's my glucose right now?"*
 | `GA_DEXCOM_CLIENT_SECRET` | **Yes** | — | Dexcom developer app client secret |
 | `GA_ENCRYPTION_KEY` | **Yes** | — | 32-byte hex-encoded AES-256 key |
 | `GA_DEXCOM_ENV` | No | `sandbox` | `sandbox` or `production` |
+| `GA_DEXCOM_REDIRECT_URI` | No | `http://localhost:8080/callback` | OAuth redirect URI — change if port 8080 is in use |
 | `GA_MCP_TRANSPORT` | No | `sse` | `sse` or `stdio` |
 | `GA_SERVER_PORT` | No | `8080` | HTTP listen port |
 | `GA_DB_PATH` | No | `/data/data.db` | SQLite database path |
 | `GA_TOKEN_PATH` | No | `/data/tokens.enc` | Encrypted token file path |
 | `GA_CONFIG_PATH` | No | `/data/config.yaml` | Optional YAML config override |
+
+> **Port conflict?** If port 8080 is already in use, set both `GA_SERVER_PORT` and `GA_DEXCOM_REDIRECT_URI` together in `.env` and update your Dexcom developer app's Redirect URI to match:
+> ```bash
+> GA_SERVER_PORT=8090
+> GA_DEXCOM_REDIRECT_URI=http://localhost:8090/callback
+> ```
 
 See `.env.example` for a template.
 


### PR DESCRIPTION
## Summary
- Added `GA_DEXCOM_REDIRECT_URI` to the README env vars table with a port conflict callout
- Added port conflict note in QUICKSTART Step 1 (Dexcom app registration) explaining that both `GA_SERVER_PORT` and `GA_DEXCOM_REDIRECT_URI` must be changed together
- Added **Port 8080 already in use** Troubleshooting entry in QUICKSTART
- Added `GA_DEXCOM_REDIRECT_URI` example to `.env.example` under a dedicated port conflict override section
- Fixed QUICKSTART Switching to Production to reference `GA_DEXCOM_REDIRECT_URI` instead of hardcoding `8080`

## Test plan
- [ ] Read through QUICKSTART as a first-time user hitting a port conflict — verify the instructions are clear and complete
- [ ] Verify `.env.example` has the two override vars commented out with explanatory comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)