### PR TITLE
docs: update Go version references from 1.22 to 1.24

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Canonical spec: `SPEC.md`. This file is the source of truth. Never deviate from 
 
 ### Phase 1 — Scaffolding (branch: `feat/scaffolding`)
 Files to create:
-- `go.mod` — module `github.com/johnmartinez/cgm-get-agent`, Go 1.22
+- `go.mod` — module `github.com/johnmartinez/cgm-get-agent`, Go 1.24
 - `.gitignore` — see Security Gitignore section below
 - `.env.example` — placeholder values only
 - `Dockerfile` — multi-stage, CGO enabled, arm64-native

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An MCP (Model Context Protocol) server that connects LLMs (Claude, ChatGPT) to a
 
 ## Stack
 
-- **Go 1.22** — single binary, CGO for SQLite
+- **Go 1.24** — single binary, CGO for SQLite
 - **MCP** — primary protocol (`github.com/modelcontextprotocol/go-sdk/mcp`), SSE + stdio transports
 - **REST shim** — OpenAI function-calling compatibility at `/v1/tools/invoke`
 - **Dexcom API v3** — OAuth2, EGV/event data from Dexcom G7
@@ -25,7 +25,7 @@ An MCP (Model Context Protocol) server that connects LLMs (Claude, ChatGPT) to a
 - macOS (Apple Silicon recommended)
 - [Colima](https://github.com/abiosoft/colima) + Docker CLI (`brew install colima docker docker-compose`)
 - A [Dexcom Developer account](https://developer.dexcom.com/) — create an app to get `client_id` and `client_secret`
-- Go 1.22+ (for local development only; not needed for Docker builds)
+- Go 1.24+ (for local development only; not needed for Docker builds)
 
 ## Quick Start
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -542,7 +542,7 @@ Tool errors are returned as `mcp.CallToolResult` with `IsError: true` and a `Tex
 ### 5.1 Dockerfile (multi-stage, arm64-native)
 
 ```
-Stage 1: golang:1.22-alpine AS builder
+Stage 1: golang:1.24-alpine AS builder
     - Install: gcc, musl-dev, sqlite-dev (CGO required for mattn/go-sqlite3)
     - WORKDIR /src
     - Copy go.mod, go.sum → go mod download

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -44,11 +44,11 @@ This document memorializes the phased build plan for the `cgm-get-agent` project
 
 | File | Purpose |
 |---|---|
-| `go.mod` | Go module declaration, Go 1.22, dependency stubs |
+| `go.mod` | Go module declaration, Go 1.24, dependency stubs |
 | `go.sum` | Generated on `go mod tidy` |
 | `.gitignore` | Excludes `.env`, `*.enc`, `data.db`, `config.yaml`, `~/.cgm-get-agent/` |
 | `.env.example` | Placeholder values for all `GA_*` env vars — safe to commit |
-| `Dockerfile` | Multi-stage build: `golang:1.22-alpine` builder → `alpine:3.19` runtime; CGO enabled; arm64-native |
+| `Dockerfile` | Multi-stage build: `golang:1.24-alpine` builder → `alpine:3.19` runtime; CGO enabled; arm64-native |
 | `docker-compose.yaml` | Service `cgm-get-agent`, volume `~/.cgm-get-agent:/data`, `env_file: .env`, healthcheck |
 
 **Acceptance criteria:**


### PR DESCRIPTION
## Summary
- Updates all Go version references across docs from 1.22 → 1.24 to match the Dockerfile base image fix landed in #20
- Files updated: `README.md`, `SPEC.md`, `CLAUDE.md`, `docs/implementation-plan.md`

## Test plan
- [ ] No code changes — doc-only update
- [ ] Verify no remaining `1.22` references in docs (`grep -r "1\.22" --include="*.md"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)