### PR TITLE
docs(claude): add issue-first workflow rule for fix requests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,10 +21,11 @@ Canonical spec: `SPEC.md`. This file is the source of truth. Never deviate from 
 
 ### Git Workflow
 - Always branch from `main` before any code changes.
-- Branch naming: `feat/<feature-name>`, `fix/<issue>`, `test/<scope>`.
+- Branch naming: `feat/<feature-name>`, `fix/<issue-number>`, `test/<scope>`, `docs/<scope>`.
 - Commit message format: `<type>(<scope>): <summary>` (conventional commits).
 - Push every branch to origin before opening PR or merging.
 - Never force-push `main`.
+- When asked to fix something: create a GitHub issue first (`gh issue create`), infer title/description/labels from the prompt, then branch as `fix/<issue-number>`, fix, PR, and merge referencing the issue.
 
 ### Code Quality
 - All packages must have `_test.go` files covering core logic.


### PR DESCRIPTION
## Summary
- Adds rule to `CLAUDE.md` Git Workflow section: when asked to fix something, create a GitHub issue first, infer title/description/labels from the prompt, branch as `fix/<issue-number>`, then fix → PR → merge referencing the issue
- Also updates branch naming convention to include `docs/<scope>`

## Test plan
- [ ] Doc-only change — verify rule is present in CLAUDE.md Git Workflow section

🤖 Generated with [Claude Code](https://claude.com/claude-code)