### PR TITLE
fix(dexcom): add timeout detection and cache fallback

### DIFF
--- a/internal/dexcom/client.go
+++ b/internal/dexcom/client.go
@@ -3,6 +3,7 @@ package dexcom
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -171,6 +172,9 @@ func (c *Client) doJSON(ctx context.Context, endpoint string, dst any) error {
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || isTimeoutError(err) {
+			return &TimeoutError{Message: err.Error()}
+		}
 		return fmt.Errorf("dexcom: HTTP request: %w", err)
 	}
 	defer resp.Body.Close()
@@ -287,4 +291,12 @@ func convertAlert(a apiAlert) (types.AlertRecord, error) {
 		AlertName:   types.AlertType(a.AlertName),
 		AlertState:  types.AlertState(a.AlertState),
 	}, nil
+}
+
+// isTimeoutError checks whether an error is a net.Error with Timeout() == true.
+// This catches http.Client deadline exceeded via the net package timeout interface.
+func isTimeoutError(err error) bool {
+	type timeout interface{ Timeout() bool }
+	var t timeout
+	return errors.As(err, &t) && t.Timeout()
 }

--- a/internal/dexcom/types.go
+++ b/internal/dexcom/types.go
@@ -50,6 +50,14 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("dexcom: API error %d: %s", e.StatusCode, e.Body)
 }
 
+// TimeoutError indicates that a Dexcom API request exceeded the HTTP client timeout.
+// Retriable — the API may respond on a subsequent attempt.
+type TimeoutError struct {
+	Message string
+}
+
+func (e *TimeoutError) Error() string { return "dexcom: timeout: " + e.Message }
+
 // WindowTooLargeError is returned when a requested date range exceeds 30 days.
 type WindowTooLargeError struct {
 	RequestedDays int

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -92,6 +92,10 @@ func classifyDexcomError(err error) (*sdkmcp.CallToolResult, any, error) {
 	if errors.As(err, &authErr) {
 		return errResult("DexcomAuthError", authErr.Message, false)
 	}
+	var timeoutErr *dexcom.TimeoutError
+	if errors.As(err, &timeoutErr) {
+		return errResult("DexcomTimeoutError", timeoutErr.Error(), true)
+	}
 	var apiErr *dexcom.APIError
 	if errors.As(err, &apiErr) {
 		return errResult("DexcomAPIError", apiErr.Error(), apiErr.StatusCode >= 500)
@@ -115,9 +119,12 @@ func (s *Server) handleGetCurrentGlucose(ctx context.Context, args getCurrentGlu
 
 	egvs, err := s.client.GetEGVs(ctx, start, end)
 	if err != nil {
-		// Graceful degradation: on 5xx, fall back to cached EGVs.
+		// Graceful degradation: on 5xx or timeout, fall back to cached EGVs.
 		var apiErr *dexcom.APIError
-		if errors.As(err, &apiErr) && apiErr.StatusCode >= 500 {
+		var timeoutErr *dexcom.TimeoutError
+		isServerErr := errors.As(err, &apiErr) && apiErr.StatusCode >= 500
+		isTimeout := errors.As(err, &timeoutErr)
+		if isServerErr || isTimeout {
 			cached, cacheErr := s.store.GetCachedEGVs(start, end)
 			if cacheErr == nil && len(cached) > 0 {
 				snapshot, snapErr := analyzer.ComputeSnapshot(cached, s.cfg.GlucoseZones)


### PR DESCRIPTION
## Summary
- Add `TimeoutError` sentinel type in `internal/dexcom/types.go`
- Detect HTTP client timeout and `context.DeadlineExceeded` in `doJSON`, return `*TimeoutError` instead of generic wrapped error
- Update `classifyDexcomError` to map `TimeoutError` → `DexcomTimeoutError` (retriable: true)
- Update `handleGetCurrentGlucose` graceful degradation to fall back to cached EGVs on timeout (same as 5xx)

Fixes #27

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` all green (9 packages)
- [ ] Manual: simulate timeout with slow mock server, verify cache fallback triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)