### PR TITLE
debug(tools): trace tool handler execution path

### DIFF
--- a/internal/dexcom/client.go
+++ b/internal/dexcom/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"time"
@@ -158,38 +159,63 @@ func (c *Client) GetAlerts(ctx context.Context, start, end time.Time) ([]types.A
 // doJSON performs a GET with a Bearer token and JSON-decodes the response into dst.
 // Returns AuthError on 401, APIError on other non-2xx responses.
 func (c *Client) doJSON(ctx context.Context, endpoint string, dst any) error {
-	token, err := c.oauth.GetValidToken(ctx)
-	if err != nil {
-		return err
+	slog.Error("DEBUG doJSON: getting valid token", "endpoint", endpoint)
+
+	// Check context before starting
+	if ctx.Err() != nil {
+		slog.Error("DEBUG doJSON: context already cancelled before GetValidToken", "endpoint", endpoint, "ctx_err", ctx.Err())
+		return fmt.Errorf("dexcom: context cancelled: %w", ctx.Err())
 	}
 
+	token, err := c.oauth.GetValidToken(ctx)
+	if err != nil {
+		slog.Error("DEBUG doJSON: GetValidToken failed", "endpoint", endpoint, "error", err)
+		return err
+	}
+	tokenPreview := token
+	if len(tokenPreview) > 8 {
+		tokenPreview = tokenPreview[:8] + "..."
+	}
+	slog.Error("DEBUG doJSON: got valid token", "endpoint", endpoint, "token_prefix", tokenPreview)
+
+	slog.Error("DEBUG doJSON: building HTTP request", "endpoint", endpoint)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
+		slog.Error("DEBUG doJSON: failed to build request", "endpoint", endpoint, "error", err)
 		return fmt.Errorf("dexcom: building request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/json")
 
+	slog.Error("DEBUG doJSON: executing HTTP request", "endpoint", endpoint, "method", "GET")
+	httpStart := time.Now()
 	resp, err := c.httpClient.Do(req)
+	httpElapsed := time.Since(httpStart)
 	if err != nil {
+		slog.Error("DEBUG doJSON: HTTP request failed", "endpoint", endpoint, "error", err, "elapsed_ms", httpElapsed.Milliseconds())
 		if errors.Is(err, context.DeadlineExceeded) || isTimeoutError(err) {
 			return &TimeoutError{Message: err.Error()}
 		}
 		return fmt.Errorf("dexcom: HTTP request: %w", err)
 	}
 	defer resp.Body.Close()
+	slog.Error("DEBUG doJSON: HTTP response received", "endpoint", endpoint, "status", resp.StatusCode, "elapsed_ms", httpElapsed.Milliseconds())
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return &AuthError{Message: "access token rejected — re-authorization may be required"}
 	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		slog.Error("DEBUG doJSON: non-200 response", "endpoint", endpoint, "status", resp.StatusCode, "body", string(body))
 		return &APIError{StatusCode: resp.StatusCode, Body: string(body)}
 	}
 
+	slog.Error("DEBUG doJSON: decoding JSON response", "endpoint", endpoint)
 	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		slog.Error("DEBUG doJSON: JSON decode failed", "endpoint", endpoint, "error", err)
 		return fmt.Errorf("dexcom: decoding response: %w", err)
 	}
+	slog.Error("DEBUG doJSON: success", "endpoint", endpoint)
 	return nil
 }
 

--- a/internal/dexcom/oauth.go
+++ b/internal/dexcom/oauth.go
@@ -129,10 +129,13 @@ func (h *OAuthHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 // GetValidToken returns a valid Dexcom access token, refreshing transparently if needed.
 // Safe for concurrent use.
 func (h *OAuthHandler) GetValidToken(ctx context.Context) (string, error) {
+	slog.Error("DEBUG GetValidToken: entering")
 	tokens, err := h.refreshIfNeeded(ctx)
 	if err != nil {
+		slog.Error("DEBUG GetValidToken: refreshIfNeeded failed", "error", err)
 		return "", err
 	}
+	slog.Error("DEBUG GetValidToken: returning valid token")
 	return tokens.AccessToken, nil
 }
 
@@ -152,29 +155,40 @@ func (h *OAuthHandler) LoadTokens() (types.OAuthTokens, error) {
 // refreshIfNeeded loads tokens from disk, refreshes if expiring within 5 minutes,
 // and returns valid tokens. The mutex ensures only one refresh happens concurrently.
 func (h *OAuthHandler) refreshIfNeeded(ctx context.Context) (types.OAuthTokens, error) {
+	slog.Error("DEBUG refreshIfNeeded: acquiring mutex")
 	h.mu.Lock()
+	slog.Error("DEBUG refreshIfNeeded: mutex acquired")
 	defer h.mu.Unlock()
 
+	slog.Error("DEBUG refreshIfNeeded: loading tokens from disk", "path", h.tokenPath)
 	// Always re-read from disk inside the lock: another goroutine may have already refreshed.
 	tokens, err := crypto.LoadTokens(h.tokenPath, h.encKey)
 	if err != nil {
+		slog.Error("DEBUG refreshIfNeeded: LoadTokens failed", "error", err)
 		return types.OAuthTokens{}, &AuthError{
 			Message: "no tokens found — visit /oauth/start to authorize",
 		}
 	}
+	slog.Error("DEBUG refreshIfNeeded: tokens loaded", "expires_at", tokens.ExpiresAt, "time_until_expiry", time.Until(tokens.ExpiresAt).String())
 
 	if time.Until(tokens.ExpiresAt) > 5*time.Minute {
+		slog.Error("DEBUG refreshIfNeeded: tokens still fresh, returning")
 		return tokens, nil // still fresh
 	}
 
+	slog.Error("DEBUG refreshIfNeeded: tokens expiring soon, refreshing")
 	refreshed, err := h.doRefresh(ctx, tokens.RefreshToken)
 	if err != nil {
+		slog.Error("DEBUG refreshIfNeeded: doRefresh failed", "error", err)
 		return types.OAuthTokens{}, fmt.Errorf("dexcom: refreshing token: %w", err)
 	}
 
+	slog.Error("DEBUG refreshIfNeeded: saving refreshed tokens")
 	if err := crypto.SaveTokens(h.tokenPath, refreshed, h.encKey); err != nil {
+		slog.Error("DEBUG refreshIfNeeded: SaveTokens failed", "error", err)
 		return types.OAuthTokens{}, fmt.Errorf("dexcom: saving refreshed tokens: %w", err)
 	}
+	slog.Error("DEBUG refreshIfNeeded: refresh complete")
 	return refreshed, nil
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -295,11 +295,27 @@ func (s *Server) handleGetDevices(ctx context.Context) (*sdkmcp.CallToolResult, 
 			slog.Error("TOOL HANDLER PANIC", "tool", "get_devices", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
+
+	// Check context state at entry
+	slog.Error("DEBUG get_devices: context check", "deadline_set", ctx.Err() == nil, "ctx_err", ctx.Err())
+	if deadline, ok := ctx.Deadline(); ok {
+		slog.Error("DEBUG get_devices: context has deadline", "deadline", deadline, "remaining", time.Until(deadline).String())
+	} else {
+		slog.Error("DEBUG get_devices: context has NO deadline")
+	}
+
+	slog.Error("DEBUG get_devices: calling s.client.GetDevices")
 	devices, err := s.client.GetDevices(ctx)
 	if err != nil {
+		slog.Error("DEBUG get_devices: GetDevices returned error", "error", err)
 		return classifyDexcomError(err)
 	}
-	return jsonResult(devices)
+	slog.Error("DEBUG get_devices: GetDevices returned success", "device_count", len(devices))
+
+	slog.Error("DEBUG get_devices: marshaling result")
+	result, extra, retErr := jsonResult(devices)
+	slog.Error("DEBUG get_devices: returning result", "is_error", result != nil && result.IsError, "has_content", result != nil && len(result.Content) > 0)
+	return result, extra, retErr
 }
 
 func (s *Server) handleGetDataRange(ctx context.Context) (*sdkmcp.CallToolResult, any, error) {
@@ -309,11 +325,23 @@ func (s *Server) handleGetDataRange(ctx context.Context) (*sdkmcp.CallToolResult
 			slog.Error("TOOL HANDLER PANIC", "tool", "get_data_range", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
+
+	slog.Error("DEBUG get_data_range: context check", "ctx_err", ctx.Err())
+	if deadline, ok := ctx.Deadline(); ok {
+		slog.Error("DEBUG get_data_range: context has deadline", "remaining", time.Until(deadline).String())
+	}
+
+	slog.Error("DEBUG get_data_range: calling s.client.GetDataRange")
 	dr, err := s.client.GetDataRange(ctx)
 	if err != nil {
+		slog.Error("DEBUG get_data_range: GetDataRange returned error", "error", err)
 		return classifyDexcomError(err)
 	}
-	return jsonResult(dr)
+	slog.Error("DEBUG get_data_range: GetDataRange returned success")
+
+	result, extra, retErr := jsonResult(dr)
+	slog.Error("DEBUG get_data_range: returning result", "has_content", result != nil && len(result.Content) > 0)
+	return result, extra, retErr
 }
 
 func (s *Server) handleLogMeal(ctx context.Context, args logMealInput) (*sdkmcp.CallToolResult, any, error) {


### PR DESCRIPTION
## Summary
- Adds granular DEBUG logging at every step of the tool handler → Dexcom API call chain to isolate where handlers hang silently
- Traces: context state at entry, mutex acquisition in `refreshIfNeeded`, token load from disk, HTTP request/response timing, JSON decode, and result marshaling
- Covers `doJSON`, `GetValidToken`, `refreshIfNeeded` (shared path), plus `get_devices`, `get_data_range` handlers specifically

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` all green
- [ ] Deploy and invoke `get_devices` — logs should now show exactly which step hangs

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)