### PR TITLE
fix(dexcom): correct JSON field tags to match Dexcom v3 response format

### DIFF
--- a/internal/dexcom/types.go
+++ b/internal/dexcom/types.go
@@ -85,7 +85,7 @@ type DeviceRecord struct {
 
 // egvsResponse is the JSON envelope from GET /v3/users/self/egvs.
 type egvsResponse struct {
-	EGVs []apiEGV `json:"egvs"`
+	EGVs []apiEGV `json:"records"`
 }
 
 // apiEGV is the raw JSON shape of a single EGV record from Dexcom.
@@ -108,7 +108,7 @@ type apiEGV struct {
 
 // eventsResponse is the JSON envelope from GET /v3/users/self/events.
 type eventsResponse struct {
-	Events []apiEvent `json:"events"`
+	Events []apiEvent `json:"records"`
 }
 
 // apiEvent is the raw JSON shape of a single event record from Dexcom.
@@ -124,7 +124,7 @@ type apiEvent struct {
 
 // calibrationsResponse is the JSON envelope from GET /v3/users/self/calibrations.
 type calibrationsResponse struct {
-	Calibrations []apiCalibration `json:"calibrations"`
+	Calibrations []apiCalibration `json:"records"`
 }
 
 // apiCalibration is the raw JSON shape of a single calibration record from Dexcom.
@@ -142,7 +142,7 @@ type apiCalibration struct {
 
 // alertsResponse is the JSON envelope from GET /v3/users/self/alerts.
 type alertsResponse struct {
-	Alerts []apiAlert `json:"alerts"`
+	Alerts []apiAlert `json:"records"`
 }
 
 // apiAlert is the raw JSON shape of a single alert event from Dexcom.
@@ -188,7 +188,7 @@ type timeRangeJSON struct {
 
 // devicesResponse is the JSON envelope from GET /v3/users/self/devices.
 type devicesResponse struct {
-	Devices []DeviceRecord `json:"devices"`
+	Devices []DeviceRecord `json:"records"`
 }
 
 // tokenResponse is the JSON body from the Dexcom token endpoint.

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -101,7 +101,7 @@ func mockEGVsJSON(baseTime time.Time, values []int) string {
 		RateUnit    string  `json:"rateUnit"`
 	}
 	type envelope struct {
-		EGVs []egv `json:"egvs"`
+		EGVs []egv `json:"records"`
 	}
 
 	env := envelope{}
@@ -248,7 +248,7 @@ func TestScenario3_MealImpactRating(t *testing.T) {
 		{RecordID: "peak", SystemTime: mealTime.Add(45 * time.Minute).Format(dexcomFmt), DisplayTime: mealTime.Add(45 * time.Minute).Format(dexcomFmt), Value: 140, Trend: "singleUp", Unit: "mg/dL", RateUnit: "mg/dL/min"},
 		{RecordID: "rec", SystemTime: mealTime.Add(120 * time.Minute).Format(dexcomFmt), DisplayTime: mealTime.Add(120 * time.Minute).Format(dexcomFmt), Value: 95, Trend: "flat", Unit: "mg/dL", RateUnit: "mg/dL/min"},
 	}
-	body, _ := json.Marshal(map[string]any{"egvs": egvs})
+	body, _ := json.Marshal(map[string]any{"records": egvs})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -373,7 +373,7 @@ func TestScenario5_DexcomAppEvents(t *testing.T) {
 		Value        *float64 `json:"value,omitempty"`
 		Unit         string   `json:"unit"`
 	}
-	resp := map[string]any{"events": []apiEvt{
+	resp := map[string]any{"records": []apiEvt{
 		{RecordID: "ev-1", SystemTime: base.Format(dexcomFmt), DisplayTime: base.Format(dexcomFmt), EventType: "carbs", Value: &carbVal, Unit: "grams"},
 		{RecordID: "ev-2", SystemTime: base.Add(5 * time.Minute).Format(dexcomFmt), DisplayTime: base.Add(5 * time.Minute).Format(dexcomFmt), EventType: "insulin", EventSubType: &subType, Value: &insulinVal, Unit: "units"},
 	}}
@@ -430,7 +430,7 @@ func TestScenario6_AlertHistoryReview(t *testing.T) {
 		AlertName   string `json:"alertName"`
 		AlertState  string `json:"alertState"`
 	}
-	resp := map[string]any{"alerts": []apiAlert{
+	resp := map[string]any{"records": []apiAlert{
 		{RecordID: "al-1", SystemTime: base.Format(dexcomFmt), DisplayTime: base.Format(dexcomFmt), AlertName: "high", AlertState: "triggered"},
 		{RecordID: "al-2", SystemTime: base.Add(30 * time.Minute).Format(dexcomFmt), DisplayTime: base.Add(30 * time.Minute).Format(dexcomFmt), AlertName: "urgentLow", AlertState: "triggered"},
 	}}
@@ -491,7 +491,7 @@ func TestScenario7_CalibrationReview(t *testing.T) {
 		DisplayDevice         string `json:"displayDevice"`
 		DisplayApp            string `json:"displayApp"`
 	}
-	resp := map[string]any{"calibrations": []apiCal{
+	resp := map[string]any{"records": []apiCal{
 		{RecordID: "cal-1", SystemTime: base.Format(dexcomFmt), DisplayTime: base.Format(dexcomFmt), Value: 108, Unit: "mg/dL", TransmitterID: "tx-1", TransmitterGeneration: "g7", DisplayDevice: "iOS", DisplayApp: "G7"},
 		{RecordID: "cal-2", SystemTime: base.Add(8 * time.Hour).Format(dexcomFmt), DisplayTime: base.Add(8 * time.Hour).Format(dexcomFmt), Value: 112, Unit: "mg/dL", TransmitterID: "tx-1", TransmitterGeneration: "g7", DisplayDevice: "iOS", DisplayApp: "G7"},
 	}}
@@ -636,7 +636,7 @@ func TestRateMealImpact_MealNotFound_ReturnsError(t *testing.T) {
 func TestGetTrend_NoData_ReturnsError(t *testing.T) {
 	// Mock returns empty EGV list.
 	type envelope struct {
-		EGVs []struct{} `json:"egvs"`
+		EGVs []struct{} `json:"records"`
 	}
 	body, _ := json.Marshal(envelope{})
 


### PR DESCRIPTION
## Summary
- All Dexcom v3 response envelopes use `"records"` as the JSON field name, but our structs used endpoint-specific names (`"egvs"`, `"events"`, `"calibrations"`, `"alerts"`, `"devices"`)
- `json.Unmarshal` silently returned empty slices despite valid HTTP 200 responses (root cause of `device_count=0` and similar issues)
- Fixed all 5 response structs in `internal/dexcom/types.go` and updated 7 test mock payloads in `internal/mcp/tools_test.go`

Fixes #32

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` — all 9 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)