### PR TITLE
feat(config): add GA_LOG_LEVEL for configurable log verbosity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ GA_ENCRYPTION_KEY=replace-with-output-of-openssl-rand-hex-32
 GA_SERVER_PORT=8090
 # GA_MCP_TRANSPORT=sse
 
+# Log verbosity: 1=ERROR (quiet), 2=INFO (default), 3=DEBUG (diagnostic)
+# GA_LOG_LEVEL=2
+
 # -------------------------------------------------------------------
 # Port conflict override
 # If port 8090 is already in use on your machine, override both vars

--- a/README.md
+++ b/README.md
@@ -125,7 +125,10 @@ Now ask Claude: *"What's my glucose right now?"*
 | `GA_SERVER_PORT` | No | `8090` | HTTP listen port |
 | `GA_DB_PATH` | No | `/data/data.db` | SQLite database path |
 | `GA_TOKEN_PATH` | No | `/data/tokens.enc` | Encrypted token file path |
+| `GA_LOG_LEVEL` | No | `2` | Log verbosity: 1=ERROR, 2=INFO, 3=DEBUG |
 | `GA_CONFIG_PATH` | No | `/data/config.yaml` | Optional YAML config override |
+
+> **Logging:** Default log level is 2 (INFO). Set `GA_LOG_LEVEL=1` for quiet mode or `GA_LOG_LEVEL=3` for full diagnostic output when troubleshooting.
 
 > **Port conflict?** If port 8090 is already in use, set both `GA_SERVER_PORT` and `GA_DEXCOM_REDIRECT_URI` together in `.env` and update your Dexcom developer app's Redirect URI to match:
 > ```bash

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -23,13 +23,23 @@ func main() {
 		os.Exit(1)
 	}
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
-
 	cfg, err := config.Load()
 	if err != nil {
-		logger.Error("config load failed", "error", err)
+		slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})).Error("config load failed", "error", err)
 		os.Exit(1)
 	}
+
+	var slogLevel slog.Level
+	switch cfg.LogLevel {
+	case 1:
+		slogLevel = slog.LevelError
+	case 3:
+		slogLevel = slog.LevelDebug
+	default:
+		slogLevel = slog.LevelInfo
+	}
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slogLevel}))
+	slog.SetDefault(logger)
 
 	st, err := store.Open(cfg.Storage.DBPath)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 		DBPath    string `yaml:"db_path"`
 		TokenPath string `yaml:"token_path"`
 	} `yaml:"storage"`
+	LogLevel      int          `yaml:"log_level"`  // 1=ERROR, 2=INFO (default), 3=DEBUG
 	EncryptionKey []byte       // decoded from GA_ENCRYPTION_KEY; never in YAML
 	GlucoseZones  GlucoseZones `yaml:"glucose_zones"`
 }
@@ -76,6 +77,7 @@ func defaults() *Config {
 	cfg.Server.Host = "0.0.0.0"
 	cfg.Storage.DBPath = "/data/data.db"
 	cfg.Storage.TokenPath = "/data/tokens.enc"
+	cfg.LogLevel = 2 // INFO
 	cfg.GlucoseZones = GlucoseZones{
 		Low:        70,
 		TargetLow:  80,
@@ -111,6 +113,11 @@ func applyEnv(cfg *Config) {
 	if v := os.Getenv("GA_SERVER_PORT"); v != "" {
 		if p, err := strconv.Atoi(v); err == nil {
 			cfg.Server.Port = p
+		}
+	}
+	if v := os.Getenv("GA_LOG_LEVEL"); v != "" {
+		if lvl, err := strconv.Atoi(v); err == nil && lvl >= 1 && lvl <= 3 {
+			cfg.LogLevel = lvl
 		}
 	}
 	if v := os.Getenv("GA_DB_PATH"); v != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -184,6 +184,43 @@ glucose_zones:
 	}
 }
 
+func TestLoad_LogLevelDefault(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("GA_LOG_LEVEL", "")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.LogLevel != 2 {
+		t.Errorf("expected default log_level=2, got %d", cfg.LogLevel)
+	}
+}
+
+func TestLoad_LogLevelEnvOverride(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("GA_LOG_LEVEL", "3")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.LogLevel != 3 {
+		t.Errorf("expected log_level=3, got %d", cfg.LogLevel)
+	}
+}
+
+func TestLoad_LogLevelInvalid(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("GA_LOG_LEVEL", "5")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Invalid value should keep default
+	if cfg.LogLevel != 2 {
+		t.Errorf("expected default log_level=2 for invalid input, got %d", cfg.LogLevel)
+	}
+}
+
 func TestLoad_EnvWinsOverYAML(t *testing.T) {
 	setRequiredEnv(t)
 	t.Setenv("GA_DEXCOM_ENV", "sandbox") // env should win over YAML

--- a/internal/dexcom/client.go
+++ b/internal/dexcom/client.go
@@ -159,63 +159,62 @@ func (c *Client) GetAlerts(ctx context.Context, start, end time.Time) ([]types.A
 // doJSON performs a GET with a Bearer token and JSON-decodes the response into dst.
 // Returns AuthError on 401, APIError on other non-2xx responses.
 func (c *Client) doJSON(ctx context.Context, endpoint string, dst any) error {
-	slog.Error("DEBUG doJSON: getting valid token", "endpoint", endpoint)
+	slog.Debug("doJSON: getting valid token", "endpoint", endpoint)
 
 	// Check context before starting
 	if ctx.Err() != nil {
-		slog.Error("DEBUG doJSON: context already cancelled before GetValidToken", "endpoint", endpoint, "ctx_err", ctx.Err())
+		slog.Debug("doJSON: context already cancelled", "endpoint", endpoint, "ctx_err", ctx.Err())
 		return fmt.Errorf("dexcom: context cancelled: %w", ctx.Err())
 	}
 
 	token, err := c.oauth.GetValidToken(ctx)
 	if err != nil {
-		slog.Error("DEBUG doJSON: GetValidToken failed", "endpoint", endpoint, "error", err)
+		slog.Debug("doJSON: GetValidToken failed", "endpoint", endpoint, "error", err)
 		return err
 	}
 	tokenPreview := token
 	if len(tokenPreview) > 8 {
 		tokenPreview = tokenPreview[:8] + "..."
 	}
-	slog.Error("DEBUG doJSON: got valid token", "endpoint", endpoint, "token_prefix", tokenPreview)
+	slog.Debug("doJSON: got valid token", "endpoint", endpoint, "token_prefix", tokenPreview)
 
-	slog.Error("DEBUG doJSON: building HTTP request", "endpoint", endpoint)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		slog.Error("DEBUG doJSON: failed to build request", "endpoint", endpoint, "error", err)
 		return fmt.Errorf("dexcom: building request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/json")
 
-	slog.Error("DEBUG doJSON: executing HTTP request", "endpoint", endpoint, "method", "GET")
+	slog.Debug("doJSON: executing HTTP request", "endpoint", endpoint)
 	httpStart := time.Now()
 	resp, err := c.httpClient.Do(req)
 	httpElapsed := time.Since(httpStart)
 	if err != nil {
-		slog.Error("DEBUG doJSON: HTTP request failed", "endpoint", endpoint, "error", err, "elapsed_ms", httpElapsed.Milliseconds())
+		slog.Error("dexcom API request failed", "endpoint", endpoint, "error", err, "elapsed_ms", httpElapsed.Milliseconds())
 		if errors.Is(err, context.DeadlineExceeded) || isTimeoutError(err) {
 			return &TimeoutError{Message: err.Error()}
 		}
 		return fmt.Errorf("dexcom: HTTP request: %w", err)
 	}
 	defer resp.Body.Close()
-	slog.Error("DEBUG doJSON: HTTP response received", "endpoint", endpoint, "status", resp.StatusCode, "elapsed_ms", httpElapsed.Milliseconds())
+	slog.Debug("doJSON: HTTP response received", "endpoint", endpoint, "status", resp.StatusCode, "elapsed_ms", httpElapsed.Milliseconds())
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return &AuthError{Message: "access token rejected — re-authorization may be required"}
 	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		slog.Error("DEBUG doJSON: non-200 response", "endpoint", endpoint, "status", resp.StatusCode, "body", string(body))
+		slog.Error("dexcom API non-200 response", "endpoint", endpoint, "status", resp.StatusCode)
+		slog.Debug("doJSON: response body", "endpoint", endpoint, "body", string(body))
 		return &APIError{StatusCode: resp.StatusCode, Body: string(body)}
 	}
 
-	slog.Error("DEBUG doJSON: decoding JSON response", "endpoint", endpoint)
+	slog.Debug("doJSON: decoding JSON response", "endpoint", endpoint)
 	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
-		slog.Error("DEBUG doJSON: JSON decode failed", "endpoint", endpoint, "error", err)
+		slog.Error("dexcom JSON decode failed", "endpoint", endpoint, "error", err)
 		return fmt.Errorf("dexcom: decoding response: %w", err)
 	}
-	slog.Error("DEBUG doJSON: success", "endpoint", endpoint)
+	slog.Debug("doJSON: success", "endpoint", endpoint)
 	return nil
 }
 

--- a/internal/dexcom/oauth.go
+++ b/internal/dexcom/oauth.go
@@ -73,8 +73,8 @@ func (h *OAuthHandler) HandleStart(w http.ResponseWriter, r *http.Request) {
 		"scope":         {"offline_access"},
 		"state":         {state},
 	}
-	slog.Error("oauth start redirect",
-		"redirect_uri_in_auth_request", h.redirectURI,
+	slog.Debug("oauth start redirect",
+		"redirect_uri", h.redirectURI,
 		"base_url", h.baseURL,
 	)
 	http.Redirect(w, r, h.baseURL+"/v3/oauth2/login?"+params.Encode(), http.StatusFound)
@@ -87,15 +87,13 @@ func (h *OAuthHandler) HandleStart(w http.ResponseWriter, r *http.Request) {
 func (h *OAuthHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	callbackTime := time.Now().UTC()
 	q := r.URL.Query()
-	slog.Error("oauth callback received",
-		"query", r.URL.RawQuery,
+	slog.Info("oauth callback received",
 		"callback_time", callbackTime.Format(time.RFC3339Nano),
 	)
 
 	if errParam := q.Get("error"); errParam != "" {
 		slog.Error("oauth callback error from Dexcom",
 			"error", errParam,
-			"error_description", q.Get("error_description"),
 		)
 		http.Error(w, "Dexcom authorization failed: "+errParam, http.StatusBadRequest)
 		return
@@ -129,13 +127,13 @@ func (h *OAuthHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 // GetValidToken returns a valid Dexcom access token, refreshing transparently if needed.
 // Safe for concurrent use.
 func (h *OAuthHandler) GetValidToken(ctx context.Context) (string, error) {
-	slog.Error("DEBUG GetValidToken: entering")
+	slog.Debug("GetValidToken: entering")
 	tokens, err := h.refreshIfNeeded(ctx)
 	if err != nil {
-		slog.Error("DEBUG GetValidToken: refreshIfNeeded failed", "error", err)
+		slog.Debug("GetValidToken: refreshIfNeeded failed", "error", err)
 		return "", err
 	}
-	slog.Error("DEBUG GetValidToken: returning valid token")
+	slog.Debug("GetValidToken: returning valid token")
 	return tokens.AccessToken, nil
 }
 
@@ -155,40 +153,40 @@ func (h *OAuthHandler) LoadTokens() (types.OAuthTokens, error) {
 // refreshIfNeeded loads tokens from disk, refreshes if expiring within 5 minutes,
 // and returns valid tokens. The mutex ensures only one refresh happens concurrently.
 func (h *OAuthHandler) refreshIfNeeded(ctx context.Context) (types.OAuthTokens, error) {
-	slog.Error("DEBUG refreshIfNeeded: acquiring mutex")
+	slog.Debug("refreshIfNeeded: acquiring mutex")
 	h.mu.Lock()
-	slog.Error("DEBUG refreshIfNeeded: mutex acquired")
+	slog.Debug("refreshIfNeeded: mutex acquired")
 	defer h.mu.Unlock()
 
-	slog.Error("DEBUG refreshIfNeeded: loading tokens from disk", "path", h.tokenPath)
+	slog.Debug("refreshIfNeeded: loading tokens from disk", "path", h.tokenPath)
 	// Always re-read from disk inside the lock: another goroutine may have already refreshed.
 	tokens, err := crypto.LoadTokens(h.tokenPath, h.encKey)
 	if err != nil {
-		slog.Error("DEBUG refreshIfNeeded: LoadTokens failed", "error", err)
+		slog.Debug("refreshIfNeeded: LoadTokens failed", "error", err)
 		return types.OAuthTokens{}, &AuthError{
 			Message: "no tokens found — visit /oauth/start to authorize",
 		}
 	}
-	slog.Error("DEBUG refreshIfNeeded: tokens loaded", "expires_at", tokens.ExpiresAt, "time_until_expiry", time.Until(tokens.ExpiresAt).String())
+	slog.Debug("refreshIfNeeded: tokens loaded", "expires_at", tokens.ExpiresAt, "time_until_expiry", time.Until(tokens.ExpiresAt).String())
 
 	if time.Until(tokens.ExpiresAt) > 5*time.Minute {
-		slog.Error("DEBUG refreshIfNeeded: tokens still fresh, returning")
+		slog.Debug("refreshIfNeeded: tokens still fresh")
 		return tokens, nil // still fresh
 	}
 
-	slog.Error("DEBUG refreshIfNeeded: tokens expiring soon, refreshing")
+	slog.Info("oauth token refresh", "reason", "expiring_soon")
 	refreshed, err := h.doRefresh(ctx, tokens.RefreshToken)
 	if err != nil {
-		slog.Error("DEBUG refreshIfNeeded: doRefresh failed", "error", err)
+		slog.Error("oauth token refresh failed", "error", err)
 		return types.OAuthTokens{}, fmt.Errorf("dexcom: refreshing token: %w", err)
 	}
 
-	slog.Error("DEBUG refreshIfNeeded: saving refreshed tokens")
+	slog.Debug("refreshIfNeeded: saving refreshed tokens")
 	if err := crypto.SaveTokens(h.tokenPath, refreshed, h.encKey); err != nil {
-		slog.Error("DEBUG refreshIfNeeded: SaveTokens failed", "error", err)
+		slog.Error("oauth token save failed", "error", err)
 		return types.OAuthTokens{}, fmt.Errorf("dexcom: saving refreshed tokens: %w", err)
 	}
-	slog.Error("DEBUG refreshIfNeeded: refresh complete")
+	slog.Info("oauth token refreshed")
 	return refreshed, nil
 }
 
@@ -207,12 +205,7 @@ func (h *OAuthHandler) doRefresh(ctx context.Context, refreshToken string) (type
 
 // exchangeCode performs the authorization_code grant: code → access_token + refresh_token.
 func (h *OAuthHandler) exchangeCode(ctx context.Context, code string) (types.OAuthTokens, error) {
-	codePreview := code
-	if len(codePreview) > 8 {
-		codePreview = codePreview[:8] + "..."
-	}
-	slog.Error("oauth exchangeCode starting",
-		"code_preview", codePreview,
+	slog.Debug("oauth exchangeCode starting",
 		"redirect_uri", h.redirectURI,
 	)
 	return h.doTokenRequest(ctx, url.Values{
@@ -228,12 +221,12 @@ func (h *OAuthHandler) exchangeCode(ctx context.Context, code string) (types.OAu
 func (h *OAuthHandler) doTokenRequest(ctx context.Context, params url.Values) (types.OAuthTokens, error) {
 	tokenURL := h.baseURL + "/v3/oauth2/token"
 
-	// Log request details (mask client_secret).
+	// Log request details at debug level (mask client_secret).
 	maskedSecret := params.Get("client_secret")
 	if len(maskedSecret) > 4 {
 		maskedSecret = maskedSecret[:4] + "****"
 	}
-	slog.Error("oauth token request",
+	slog.Debug("oauth token request",
 		"url", tokenURL,
 		"grant_type", params.Get("grant_type"),
 		"client_id", params.Get("client_id"),
@@ -241,7 +234,6 @@ func (h *OAuthHandler) doTokenRequest(ctx context.Context, params url.Values) (t
 		"redirect_uri", params.Get("redirect_uri"),
 		"has_code", params.Get("code") != "",
 		"has_refresh_token", params.Get("refresh_token") != "",
-		"request_time", time.Now().UTC().Format(time.RFC3339Nano),
 	)
 
 	req, err := http.NewRequestWithContext(
@@ -266,17 +258,15 @@ func (h *OAuthHandler) doTokenRequest(ctx context.Context, params url.Values) (t
 	}
 	defer resp.Body.Close()
 
-	slog.Error("oauth token response",
+	slog.Debug("oauth token response",
 		"status", resp.StatusCode,
 		"elapsed_ms", elapsed.Milliseconds(),
-		"response_time", time.Now().UTC().Format(time.RFC3339Nano),
 	)
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		slog.Error("oauth token endpoint error",
 			"status", resp.StatusCode,
-			"response_body", string(body),
 		)
 		return types.OAuthTokens{}, &AuthError{
 			Message: fmt.Sprintf("token endpoint returned HTTP %d: %s", resp.StatusCode, string(body)),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -112,10 +112,10 @@ func classifyDexcomError(err error) (*sdkmcp.CallToolResult, any, error) {
 // --- Tool handlers ---
 
 func (s *Server) handleGetCurrentGlucose(ctx context.Context, args getCurrentGlucoseInput) (*sdkmcp.CallToolResult, any, error) {
-	slog.Error("TOOL HANDLER ENTERED", "tool", "get_current_glucose")
+	slog.Info("tool call received", "tool", "get_current_glucose")
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("TOOL HANDLER PANIC", "tool", "get_current_glucose", "panic", r, "stack", string(debug.Stack()))
+			slog.Error("tool handler panic", "tool", "get_current_glucose", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 	histMinutes := args.HistoryMinutes
@@ -162,10 +162,10 @@ func (s *Server) handleGetCurrentGlucose(ctx context.Context, args getCurrentGlu
 }
 
 func (s *Server) handleGetGlucoseHistory(ctx context.Context, args getDateRangeInput) (*sdkmcp.CallToolResult, any, error) {
-	slog.Error("TOOL HANDLER ENTERED", "tool", "get_glucose_history")
+	slog.Info("tool call received", "tool", "get_glucose_history")
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("TOOL HANDLER PANIC", "tool", "get_glucose_history", "panic", r, "stack", string(debug.Stack()))
+			slog.Error("tool handler panic", "tool", "get_glucose_history", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 	start, err := parseDate(args.StartDate)
@@ -185,10 +185,10 @@ func (s *Server) handleGetGlucoseHistory(ctx context.Context, args getDateRangeI
 }
 
 func (s *Server) handleGetTrend(ctx context.Context) (*sdkmcp.CallToolResult, any, error) {
-	slog.Error("TOOL HANDLER ENTERED", "tool", "get_trend")
+	slog.Info("tool call received", "tool", "get_trend")
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("TOOL HANDLER PANIC", "tool", "get_trend", "panic", r, "stack", string(debug.Stack()))
+			slog.Error("tool handler panic", "tool", "get_trend", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 	end := time.Now().UTC()
@@ -220,10 +220,10 @@ func (s *Server) handleGetTrend(ctx context.Context) (*sdkmcp.CallToolResult, an
 }
 
 func (s *Server) handleGetDexcomEvents(ctx context.Context, args getDateRangeInput) (*sdkmcp.CallToolResult, any, error) {
-	slog.Error("TOOL HANDLER ENTERED", "tool", "get_dexcom_events")
+	slog.Info("tool call received", "tool", "get_dexcom_events")
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("TOOL HANDLER PANIC", "tool", "get_dexcom_events", "panic", r, "stack", string(debug.Stack()))
+			slog.Error("tool handler panic", "tool", "get_dexcom_events", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 	start, err := parseDate(args.StartDate)
@@ -243,10 +243,10 @@ func (s *Server) handleGetDexcomEvents(ctx context.Context, args getDateRangeInp
 }
 
 func (s *Server) handleGetCalibrations(ctx context.Context, args getDateRangeInput) (*sdkmcp.CallToolResult, any, error) {
-	slog.Error("TOOL HANDLER ENTERED", "tool", "get_calibrations")
+	slog.Info("tool call received", "tool", "get_calibrations")
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("TOOL HANDLER PANIC", "tool", "get_calibrations", "panic", r, "stack", string(debug.Stack()))
+			slog.Error("tool handler panic", "tool", "get_calibrations", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 	start, err := parseDate(args.StartDate)
@@ -266,10 +266,10 @@ func (s *Server) handleGetCalibrations(ctx context.Context, args getDateRangeInp
 }
 
 func (s *Server) handleGetAlerts(ctx context.Context, args getDateRangeInput) (*sdkmcp.CallToolResult, any, error) {
-	slog.Error("TOOL HANDLER ENTERED", "tool", "get_alerts")
+	slog.Info("tool call received", "tool", "get_alerts")
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("TOOL HANDLER PANIC", "tool", "get_alerts", "panic", r, "stack", string(debug.Stack()))
+			slog.Error("tool handler panic", "tool", "get_alerts", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 	start, err := parseDate(args.StartDate)
@@ -289,66 +289,54 @@ func (s *Server) handleGetAlerts(ctx context.Context, args getDateRangeInput) (*
 }
 
 func (s *Server) handleGetDevices(ctx context.Context) (*sdkmcp.CallToolResult, any, error) {
-	slog.Error("TOOL HANDLER ENTERED", "tool", "get_devices")
+	slog.Info("tool call received", "tool", "get_devices")
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("TOOL HANDLER PANIC", "tool", "get_devices", "panic", r, "stack", string(debug.Stack()))
+			slog.Error("tool handler panic", "tool", "get_devices", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 
-	// Check context state at entry
-	slog.Error("DEBUG get_devices: context check", "deadline_set", ctx.Err() == nil, "ctx_err", ctx.Err())
+	slog.Debug("get_devices: context check", "ctx_err", ctx.Err())
 	if deadline, ok := ctx.Deadline(); ok {
-		slog.Error("DEBUG get_devices: context has deadline", "deadline", deadline, "remaining", time.Until(deadline).String())
-	} else {
-		slog.Error("DEBUG get_devices: context has NO deadline")
+		slog.Debug("get_devices: context has deadline", "remaining", time.Until(deadline).String())
 	}
 
-	slog.Error("DEBUG get_devices: calling s.client.GetDevices")
 	devices, err := s.client.GetDevices(ctx)
 	if err != nil {
-		slog.Error("DEBUG get_devices: GetDevices returned error", "error", err)
+		slog.Debug("get_devices: error", "error", err)
 		return classifyDexcomError(err)
 	}
-	slog.Error("DEBUG get_devices: GetDevices returned success", "device_count", len(devices))
-
-	slog.Error("DEBUG get_devices: marshaling result")
-	result, extra, retErr := jsonResult(devices)
-	slog.Error("DEBUG get_devices: returning result", "is_error", result != nil && result.IsError, "has_content", result != nil && len(result.Content) > 0)
-	return result, extra, retErr
+	slog.Debug("get_devices: success", "device_count", len(devices))
+	return jsonResult(devices)
 }
 
 func (s *Server) handleGetDataRange(ctx context.Context) (*sdkmcp.CallToolResult, any, error) {
-	slog.Error("TOOL HANDLER ENTERED", "tool", "get_data_range")
+	slog.Info("tool call received", "tool", "get_data_range")
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("TOOL HANDLER PANIC", "tool", "get_data_range", "panic", r, "stack", string(debug.Stack()))
+			slog.Error("tool handler panic", "tool", "get_data_range", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 
-	slog.Error("DEBUG get_data_range: context check", "ctx_err", ctx.Err())
+	slog.Debug("get_data_range: context check", "ctx_err", ctx.Err())
 	if deadline, ok := ctx.Deadline(); ok {
-		slog.Error("DEBUG get_data_range: context has deadline", "remaining", time.Until(deadline).String())
+		slog.Debug("get_data_range: context has deadline", "remaining", time.Until(deadline).String())
 	}
 
-	slog.Error("DEBUG get_data_range: calling s.client.GetDataRange")
 	dr, err := s.client.GetDataRange(ctx)
 	if err != nil {
-		slog.Error("DEBUG get_data_range: GetDataRange returned error", "error", err)
+		slog.Debug("get_data_range: error", "error", err)
 		return classifyDexcomError(err)
 	}
-	slog.Error("DEBUG get_data_range: GetDataRange returned success")
-
-	result, extra, retErr := jsonResult(dr)
-	slog.Error("DEBUG get_data_range: returning result", "has_content", result != nil && len(result.Content) > 0)
-	return result, extra, retErr
+	slog.Debug("get_data_range: success")
+	return jsonResult(dr)
 }
 
 func (s *Server) handleLogMeal(ctx context.Context, args logMealInput) (*sdkmcp.CallToolResult, any, error) {
-	slog.Error("TOOL HANDLER ENTERED", "tool", "log_meal")
+	slog.Info("tool call received", "tool", "log_meal")
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("TOOL HANDLER PANIC", "tool", "log_meal", "panic", r, "stack", string(debug.Stack()))
+			slog.Error("tool handler panic", "tool", "log_meal", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 	if args.Description == "" {
@@ -381,10 +369,10 @@ func (s *Server) handleLogMeal(ctx context.Context, args logMealInput) (*sdkmcp.
 }
 
 func (s *Server) handleLogExercise(_ context.Context, args logExerciseInput) (*sdkmcp.CallToolResult, any, error) {
-	slog.Error("TOOL HANDLER ENTERED", "tool", "log_exercise")
+	slog.Info("tool call received", "tool", "log_exercise")
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("TOOL HANDLER PANIC", "tool", "log_exercise", "panic", r, "stack", string(debug.Stack()))
+			slog.Error("tool handler panic", "tool", "log_exercise", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 	if args.Type == "" {
@@ -422,10 +410,10 @@ func (s *Server) handleLogExercise(_ context.Context, args logExerciseInput) (*s
 }
 
 func (s *Server) handleRateMealImpact(ctx context.Context, args rateMealImpactInput) (*sdkmcp.CallToolResult, any, error) {
-	slog.Error("TOOL HANDLER ENTERED", "tool", "rate_meal_impact")
+	slog.Info("tool call received", "tool", "rate_meal_impact")
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("TOOL HANDLER PANIC", "tool", "rate_meal_impact", "panic", r, "stack", string(debug.Stack()))
+			slog.Error("tool handler panic", "tool", "rate_meal_impact", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 	if args.MealID == "" {


### PR DESCRIPTION
## Summary
- Adds `GA_LOG_LEVEL` env var: 1=ERROR (quiet), 2=INFO (default), 3=DEBUG (full diagnostic)
- Reclassifies all existing slog calls from ERROR to their correct levels:
  - **DEBUG**: tool entry/exit traces, context/deadline checks, mutex acquisition, HTTP request/response details, JSON decode steps, token prefix previews
  - **INFO**: tool calls received (name only), OAuth callback received, token refresh events
  - **ERROR**: actual failures (API errors, panics, auth failures, decode errors)
- No PHI at any level; secrets masked (token prefix only, client_secret first 4 chars) at DEBUG
- Config: `LogLevel` field in Config struct, loaded from YAML `log_level` or `GA_LOG_LEVEL` env var
- `slog.SetDefault()` called in main.go so all packages pick up the configured level
- Tests: 3 new config tests (default, env override, invalid value)
- Updated `.env.example` and README env var table

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` — all 9 packages pass
- [x] New tests verify default=2, env override to 3, invalid values keep default

🤖 Generated with [Claude Code](https://claude.com/claude-code)