### PR TITLE
docs: add troubleshooting note for post-auth data gap

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -247,6 +247,9 @@ docker compose logs cgm-get-agent
 ```
 Most common cause: missing or incorrect values in `.env`.
 
+**Data gap after fresh install or re-authorization**
+After a fresh install, rebuild with new tokens, or re-authorization, you may only see historical data from your previous auth session. Recent readings (last 1-2 hours) will backfill as the Dexcom API syncs with your new OAuth tokens. Wait an hour and try again — your G7 sensor has been uploading continuously, the API just needs time to serve it under the new authorization.
+
 **Restart after reboot**
 ```bash
 colima start --arch aarch64 --vm-type vz

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ open http://localhost:8090/oauth/start   # re-authorize with real credentials
 - The host volume `~/.cgm-get-agent` should be `chmod 700`.
 - No data is transmitted to any third party other than the Dexcom API.
 - Never expose port 8090 directly to the internet. Use Tailscale or WireGuard for remote access.
+- After a fresh install, rebuild, or re-authorization, recent readings (last 1-2 hours) may be temporarily unavailable while the Dexcom API syncs with your new OAuth tokens. Historical data backfills within an hour.
 
 ## Development
 


### PR DESCRIPTION
## Summary

- QUICKSTART.md: Added troubleshooting entry for data gap after fresh install or re-authorization
- README.md: Added note to Data & Privacy section about post-auth backfill delay

Fixes #45

## Test plan

- [ ] Verify troubleshooting entry renders correctly in QUICKSTART.md
- [ ] Verify README.md Data & Privacy bullet renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)